### PR TITLE
Add planner implementation

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -3,17 +3,20 @@ package plan
 import (
 	"context"
 
+	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
 )
 
 // ResourceState represents the state of a resource.
-type ResourceState string
+type ResourceState int
 
 const (
+	// ResourceStateUnknown represents an unknown state
+	ResourceStateUnknown ResourceState = iota
 	// ResourceStateExists represents a state where the resource should exists.
-	ResourceStateExists ResourceState = "exists"
+	ResourceStateExists
 	// ResourceStateMissing represents a state where the resource should be missing.
-	ResourceStateMissing ResourceState = "missing"
+	ResourceStateMissing
 )
 
 // State is the state of a plan of states.
@@ -22,19 +25,66 @@ type State struct {
 	Resource model.Resource
 }
 
-// Planner knows how to make an plan of resources based on an old group
+// Planner knows how to make an plan of resource state based on an old group
 // of resources and a new one.
 type Planner interface {
 	Plan(ctx context.Context, expected []model.Resource, current []model.Resource) ([]State, error)
 }
 
-type planner struct{}
-
-// NewPlanner returns a new planner.
-func NewPlanner() Planner {
-	return planner{}
+type planner struct {
+	logger log.Logger
 }
 
+// NewPlanner returns a new planner.
+func NewPlanner(logger log.Logger) Planner {
+	return planner{
+		logger: logger.WithValues(log.Kv{"app-svc": "plan.Planner"}),
+	}
+}
+
+// Plan plans the states by comparing an expected state and the current state.
 func (p planner) Plan(ctx context.Context, expected []model.Resource, current []model.Resource) ([]State, error) {
-	return nil, nil
+	currentIdx := indexResources(current)
+	expectedIdx := indexResources(expected)
+
+	missingQ := 0
+	existsQ := 0
+	states := []State{}
+
+	// Add the ones that we know need to exist.
+	for _, r := range expectedIdx {
+		existsQ++
+		states = append(states, State{
+			State:    ResourceStateExists,
+			Resource: r,
+		})
+	}
+
+	// Add the ones that have been deleted.
+	for id, r := range currentIdx {
+		_, ok := expectedIdx[id]
+		if ok {
+			continue
+		}
+
+		// This resources has been deleted.
+		missingQ++
+		states = append(states, State{
+			State:    ResourceStateMissing,
+			Resource: r,
+		})
+	}
+
+	p.logger.Infof("%d planned states, %d missing, %d exists", len(states), missingQ, existsQ)
+
+	return states, nil
+}
+
+func indexResources(rs []model.Resource) map[string]model.Resource {
+	index := map[string]model.Resource{}
+	for _, r := range rs {
+		index[r.ID] = r
+	}
+
+	return index
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,124 @@
+package plan_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slok/kahoy/internal/log"
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/plan"
+)
+
+func TestPlannerPlan(t *testing.T) {
+	tests := map[string]struct {
+		currentRes  []model.Resource
+		expectedRes []model.Resource
+		expState    []plan.State
+		expErr      error
+	}{
+		"Without current and expected resources, should plan empty list of states.": {
+			expState: []plan.State{},
+		},
+
+		"Without current and with expected resources, should plan list withouth missing states.": {
+			currentRes: []model.Resource{},
+			expectedRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateExists},
+			},
+		},
+
+		"With same current and expected resources, should plan list withouth missing states.": {
+			currentRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expectedRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateExists},
+			},
+		},
+
+		"With deleted in the expected resources, should plan list with missing states.": {
+			currentRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expectedRes: []model.Resource{},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateMissing},
+			},
+		},
+
+		"With some deleted and some new in the expected resources, should plan list with missing states.": {
+			currentRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expectedRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test2"},
+				{ID: "test4"},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test4"}, State: plan.ResourceStateExists},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			p := plan.NewPlanner(log.Noop)
+			gotState, err := p.Plan(context.TODO(), test.expectedRes, test.currentRes)
+
+			if test.expErr != nil {
+				assert.True(errors.Is(err, test.expErr))
+			} else if assert.NoError(err) {
+				sortStateList(test.expState)
+				sortStateList(gotState)
+				assert.Equal(test.expState, gotState)
+			}
+		})
+	}
+}
+
+func sortStateList(l []plan.State) {
+	sort.SliceStable(l, func(i, j int) bool {
+		return l[i].Resource.ID < l[j].Resource.ID
+	})
+}


### PR DESCRIPTION
Closes #7 

This PR implements the default planner, this planner crates the plan resource states by comparing the current/old states and the expected/new states, it adds all the new states as _should exist_, and the old ones that don't exist anymore as the _should be gone_ ones.