### PR TITLE
Allow using git diffs to filter what enters in the plan process

### DIFF
--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -34,6 +35,7 @@ type CmdConfig struct {
 		ExcludeManifests         []string
 		IncludeManifests         []string
 		ExcludeKubeTypeResources []string
+		GitDiffFile              *os.File
 		DryRun                   bool
 	}
 }
@@ -61,6 +63,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("fs-new-manifests-path", "kubernetes expected manifests path.").Required().StringVar(&c.Apply.ManifestsPathNew)
 	apply.Flag("fs-exclude", "regex to ignore manifest files and dirs. Can be repeated.").StringsVar(&c.Apply.ExcludeManifests)
 	apply.Flag("fs-include", "regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").StringsVar(&c.Apply.IncludeManifests)
+	apply.Flag("fs-include-git-diff", "name-only git diff (`git diff --name-only`) content path, that will be used as the filter everything else except these when loading manifests.").FileVar(&c.Apply.GitDiffFile)
 	apply.Flag("kube-exclude-type", "regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").StringsVar(&c.Apply.ExcludeKubeTypeResources)
 	apply.Flag("dry-run", "execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,28 @@
+package git
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// DiffNameOnlyToFSInclude gets a Git diff based on name (`git diff --name-only`) and
+// returns as a FS compatible `Include` paths options.
+// This can be used to only load the files changed in a git diff.
+func DiffNameOnlyToFSInclude(diff io.Reader) []string {
+	paths := []string{}
+
+	sc := bufio.NewScanner(diff)
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			continue
+		}
+		line = strings.ReplaceAll(line, "/", `\/`)
+		pathRegex := fmt.Sprintf(`.*\/%s$`, line)
+		paths = append(paths, pathRegex)
+	}
+
+	return paths
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,57 @@
+package git_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/slok/kahoy/internal/git"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffNameOnlyToFSInclude(t *testing.T) {
+	tests := map[string]struct {
+		diff        string
+		expIncludes []string
+	}{
+		"No lines should return empty includes.": {
+			diff:        "",
+			expIncludes: []string{},
+		},
+
+		"Having multiple lines should return the include regexes.": {
+			diff: `
+README.md
+manifests/grafana/grafana-dashboards/grafana-dashboards-dev.yaml
+manifests/grafana/grafana-dashboards/grafana-dashboards-house.yaml
+manifests/grafana/grafana-dashboards/grafana-dashboards-infra.yaml
+manifests/grafana/grafana-dashboards/grafana-dashboards-kubernetes.yaml
+manifests/grafana/grafana-dashboards/grafana-dashboards-provision.yaml
+manifests/grafana/grafana.yaml
+manifests/dex/dex-secret.yaml
+manifests/dex/dex.yaml
+`,
+			expIncludes: []string{
+				`.*\/README.md$`,
+				`.*\/manifests\/grafana\/grafana-dashboards\/grafana-dashboards-dev.yaml$`,
+				`.*\/manifests\/grafana\/grafana-dashboards\/grafana-dashboards-house.yaml$`,
+				`.*\/manifests\/grafana\/grafana-dashboards\/grafana-dashboards-infra.yaml$`,
+				`.*\/manifests\/grafana\/grafana-dashboards\/grafana-dashboards-kubernetes.yaml$`,
+				`.*\/manifests\/grafana\/grafana-dashboards\/grafana-dashboards-provision.yaml$`,
+				`.*\/manifests\/grafana\/grafana.yaml$`,
+				`.*\/manifests\/dex\/dex-secret.yaml$`,
+				`.*\/manifests\/dex\/dex.yaml$`,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			diff := strings.NewReader(test.diff)
+			gotIncludes := git.DiffNameOnlyToFSInclude(diff)
+
+			assert.Equal(test.expIncludes, gotIncludes)
+		})
+	}
+}

--- a/internal/storage/fs/fs_test.go
+++ b/internal/storage/fs/fs_test.go
@@ -93,6 +93,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 				// Mock 1 file.
 				f1Path := "/tmp/test/test-1.yaml"
 				f1 := testInfoFile{name: "test-1.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-1.yaml").Once().Return([]byte("f1"), nil)
 				objs := []model.K8sObject{newConfigmap("test-ns", "test-name")}
 				mkd.On("DecodeObjects", mock.Anything, []byte("f1")).Once().Return(objs, nil)
@@ -125,6 +126,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 				// Mock 1 file.
 				f1Path := "/tmp/test/test-1.yaml"
 				f1 := testInfoFile{name: "test-1.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-1.yaml").Once().Return([]byte("f1"), nil)
 				objs := []model.K8sObject{
 					newConfigmap("test-ns", "test-name"),
@@ -167,6 +169,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 				// Mock 2 files.
 				f1Path := "/tmp/test/test-1.yaml"
 				f1 := testInfoFile{name: "test-1.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-1.yaml").Once().Return([]byte("f1"), nil)
 				objs := []model.K8sObject{
 					newConfigmap("test-ns", "test-name"),
@@ -175,6 +178,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 
 				f2Path := "/tmp/test/test-2.yaml"
 				f2 := testInfoFile{name: "test-2.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-2.yaml").Once().Return("/tmp/test/test-2.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-2.yaml").Once().Return([]byte("f2"), nil)
 				objs2 := []model.K8sObject{
 					newConfigmap("test-ns2", "test-name2"),
@@ -217,6 +221,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 				// Mock 2 files.
 				f1Path := "/tmp/test/test-1.yaml"
 				f1 := testInfoFile{name: "test-1.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-1.yaml").Once().Return([]byte("f1"), nil)
 				objs := []model.K8sObject{
 					newConfigmap("test-ns", "test-name"),
@@ -225,6 +230,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 
 				f2Path := "/tmp/test/test2/test-2.yaml"
 				f2 := testInfoFile{name: "test-2.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test2/test-2.yaml").Once().Return("/tmp/test/test2/test-2.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test2/test-2.yaml").Once().Return([]byte("f2"), nil)
 				objs2 := []model.K8sObject{
 					newConfigmap("test-ns2", "test-name2"),
@@ -310,10 +316,13 @@ func TestRepositoryLoadFS(t *testing.T) {
 			mock: func(mfsm *fsmock.FileSystemManager, mkd *fsmock.K8sObjectDecoder) {
 				// Mock 3 files.
 				f1Path := "/tmp/test/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				f1 := testInfoFile{name: "test1", isDir: false}
 				f2Path := "/tmp/test2/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test2/test-1.yaml").Once().Return("/tmp/test2/test-1.yaml", nil)
 				f2 := testInfoFile{name: "test2", isDir: false}
 				f3Path := "/tmp/test3/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test3/test-1.yaml").Once().Return("/tmp/test3/test-1.yaml", nil)
 				f3 := testInfoFile{name: "test3", isDir: false}
 
 				// The file that is included.
@@ -354,10 +363,13 @@ func TestRepositoryLoadFS(t *testing.T) {
 			mock: func(mfsm *fsmock.FileSystemManager, mkd *fsmock.K8sObjectDecoder) {
 				// Mock 3 files.
 				f1Path := "/tmp/test/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				f1 := testInfoFile{name: "test1", isDir: false}
 				f2Path := "/tmp/test2/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test2/test-1.yaml").Once().Return("/tmp/test2/test-1.yaml", nil)
 				f2 := testInfoFile{name: "test2", isDir: false}
 				f3Path := "/tmp/test3/test-1.yaml"
+				mfsm.On("Abs", "/tmp/test3/test-1.yaml").Once().Return("/tmp/test3/test-1.yaml", nil)
 				f3 := testInfoFile{name: "test3", isDir: false}
 
 				// Mock all fs walks that will trigger the other mocks.
@@ -400,6 +412,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 				// Mock 1 file.
 				f1Path := "/tmp/test/test-1.yaml"
 				f1 := testInfoFile{name: "test-1.yaml", isDir: false}
+				mfsm.On("Abs", "/tmp/test/test-1.yaml").Once().Return("/tmp/test/test-1.yaml", nil)
 				mfsm.On("ReadFile", "/tmp/test/test-1.yaml").Once().Return([]byte("f1"), nil)
 				objs := []model.K8sObject{
 					newConfigmap("test-ns", "test-name"),
@@ -408,6 +421,7 @@ func TestRepositoryLoadFS(t *testing.T) {
 
 				// Ignored file.
 				f2Path := "/tmp/test/test-2.yaml"
+				mfsm.On("Abs", "/tmp/test/test-2.yaml").Once().Return("/tmp/test/test-2.yaml", nil)
 				f2 := testInfoFile{name: "test-2.yaml", isDir: false}
 
 				// Mock all fs walks that will trigger the other mocks.

--- a/internal/storage/fs/fsmock/file_system_manager.go
+++ b/internal/storage/fs/fsmock/file_system_manager.go
@@ -13,6 +13,27 @@ type FileSystemManager struct {
 	mock.Mock
 }
 
+// Abs provides a mock function with given fields: path
+func (_m *FileSystemManager) Abs(path string) (string, error) {
+	ret := _m.Called(path)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ReadFile provides a mock function with given fields: path
 func (_m *FileSystemManager) ReadFile(path string) ([]byte, error) {
 	ret := _m.Called(path)


### PR DESCRIPTION
Closes #28 

This PR adds support for `git diff --name-only` inputs.

Also now the FS include/exclude paths use the absolute path for comparison.