### PR TITLE
Fix resolving branch to hash on git memory cloned repositories

### DIFF
--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -75,7 +75,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("fs-include", "regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").StringsVar(&c.Apply.IncludeManifests)
 	apply.Flag("git-diff-filter", "excludes everything except the files changed in before-commit and HEAD git diff.").BoolVar(&c.Apply.GitDiffFilter)
 	apply.Flag("git-before-commit-sha", "the git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").StringVar(&c.Apply.GitBeforeCommit)
-	apply.Flag("git-default-branch", "git repository default branch.").Default("origin/master").StringVar(&c.Apply.GitDefaultBranch)
+	apply.Flag("git-default-branch", "git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
 	apply.Flag("kube-exclude-type", "regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").StringsVar(&c.Apply.ExcludeKubeTypeResources)
 
 	// Parse the commandline.

--- a/internal/storage/git/factory_test.go
+++ b/internal/storage/git/factory_test.go
@@ -228,7 +228,7 @@ func TestNewRepositories(t *testing.T) {
 				mNew.On("CommitObject", expHash).Once().Return(commit, nil)
 
 				// Check get other branch commit.
-				expOtherBranch := plumbing.Revision("main")
+				expOtherBranch := plumbing.Revision("refs/remotes/origin/main")
 				otherHEADHash := plumbing.NewHash("1dd111de9c9b61d7955e08078ef58a92460f7cca")
 				mNew.On("ResolveRevision", expOtherBranch).Once().Return(&otherHEADHash, nil)
 				otherCommit := &object.Commit{Hash: otherHEADHash}


### PR DESCRIPTION
When we clone the original (disk) repository into our memory copies, git clones into memory the repos with our disk repo as a remote. This makes the disk repo local branches being referenced in the memory repos as remotes. That's why on memory repos we lost all the remotes of the origin/disk repository.

For our use case, this is not a problem because we restrict the user to use only local branches for the default-branch. So, as we already know that we restrict usage to only local branches, we know that the branch used will be a remote on our memory repositories.