### PR TITLE
Add short cli arguments

### DIFF
--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -72,19 +72,19 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 
 	// Apply command.
 	apply := app.Command(CmdArgApply, "Will take all the manifests in the directory and apply to a Kubernetes cluster.")
-	apply.Flag("kube-config", "kubernetes configuration configuration path.").Default(kubeHome).StringVar(&c.Apply.KubeConfig)
+	apply.Flag("kube-config", "kubernetes configuration configuration path.").Envar("KUBECONFIG").Default(kubeHome).StringVar(&c.Apply.KubeConfig)
 	apply.Flag("kube-context", "kubernetes configuration context.").StringVar(&c.Apply.KubeContext)
 	apply.Flag("diff", "diff instead of applying changes.").BoolVar(&c.Apply.DiffMode)
 	apply.Flag("dry-run", "execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
 	apply.Flag("mode", "selects how apply will select the state, load manifests... git needs to be executed from a git repository.").Default(ApplyModeGit).EnumVar(&c.Apply.Mode, ApplyModePaths, ApplyModeGit)
-	apply.Flag("fs-old-manifests-path", "kubernetes current manifests path.").StringVar(&c.Apply.ManifestsPathOld)
-	apply.Flag("fs-new-manifests-path", "kubernetes expected manifests path.").Required().StringVar(&c.Apply.ManifestsPathNew)
-	apply.Flag("fs-exclude", "regex to ignore manifest files and dirs. Can be repeated.").StringsVar(&c.Apply.ExcludeManifests)
-	apply.Flag("fs-include", "regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").StringsVar(&c.Apply.IncludeManifests)
-	apply.Flag("git-diff-filter", "excludes everything except the files changed in before-commit and HEAD git diff.").BoolVar(&c.Apply.GitDiffFilter)
-	apply.Flag("git-before-commit-sha", "the git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").StringVar(&c.Apply.GitBeforeCommit)
+	apply.Flag("fs-old-manifests-path", "kubernetes current manifests path.").Short('o').StringVar(&c.Apply.ManifestsPathOld)
+	apply.Flag("fs-new-manifests-path", "kubernetes expected manifests path.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
+	apply.Flag("fs-exclude", "regex to ignore manifest files and dirs. Can be repeated.").Short('e').StringsVar(&c.Apply.ExcludeManifests)
+	apply.Flag("fs-include", "regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").Short('i').StringsVar(&c.Apply.IncludeManifests)
+	apply.Flag("git-diff-filter", "excludes everything except the files changed in before-commit and HEAD git diff.").Short('f').BoolVar(&c.Apply.GitDiffFilter)
+	apply.Flag("git-before-commit-sha", "the git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)
 	apply.Flag("git-default-branch", "git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
-	apply.Flag("kube-exclude-type", "regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").StringsVar(&c.Apply.ExcludeKubeTypeResources)
+	apply.Flag("kube-exclude-type", "regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('a').StringsVar(&c.Apply.ExcludeKubeTypeResources)
 
 	// Parse the commandline.
 	cmd, err := app.Parse(args)


### PR DESCRIPTION
Closes #69 

```text
Flags:
      --help                     Show context-sensitive help (also try --help-long and --help-man).
      --version                  Show application version.
      --debug                    Enable debug mode.
      --no-color                 Disable color.
      --no-log                   Disable logger.
      --config-file="kahoy.yml"  App configuration file.
      --kube-config="/home/slok/.kube/config"  
                                 kubernetes configuration configuration path.
      --kube-context=KUBE-CONTEXT  
                                 kubernetes configuration context.
      --diff                     diff instead of applying changes.
      --dry-run                  execute in dry-run, is safe, can be run without Kubernetes cluster.
      --mode=git                 selects how apply will select the state, load manifests... git needs to be executed from a git repository.
  -o, --fs-old-manifests-path=FS-OLD-MANIFESTS-PATH  
                                 kubernetes current manifests path.
  -n, --fs-new-manifests-path=FS-NEW-MANIFESTS-PATH  
                                 kubernetes expected manifests path.
  -e, --fs-exclude=FS-EXCLUDE ...  
                                 regex to ignore manifest files and dirs. Can be repeated.
  -i, --fs-include=FS-INCLUDE ...  
                                 regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.
  -f, --git-diff-filter          excludes everything except the files changed in before-commit and HEAD git diff.
  -c, --git-before-commit-sha=GIT-BEFORE-COMMIT-SHA  
                                 the git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.
      --git-default-branch="master"  
                                 git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).
  -a, --kube-exclude-type=KUBE-EXCLUDE-TYPE ...  
                                 regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.

```