### PR TITLE
Prepare CI for releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,7 @@ jobs:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           file: ./.test_coverage.txt
 
-  release-image:
-    # Only on tags.
-    #if: startsWith(github.ref, 'refs/tags/')
+  rolling-release-image:
     # Only on master.
     if: startsWith(github.ref, 'refs/heads/master')
     env:
@@ -38,12 +36,11 @@ jobs:
     name: Release image
     runs-on: ubuntu-latest
     steps:
+      # Set up SHA as version.
       - name: Set tag on VERSION env var
-        # Set up tag
-        #run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF:10})
-        # Set up the sha.
         run: echo ::set-env name=VERSION::${GITHUB_SHA}
       - uses: actions/checkout@v2
+      
       - name: Build image
         run: make build-image
       - name: Docker login
@@ -54,3 +51,54 @@ jobs:
           DOCKER_TOKEN: ${{secrets.DOCKER_HUB_TOKEN}}
       - name: Publish image
         run: make publish-image
+
+  tagged-release-image:
+    # Only on tags.
+    if: startsWith(github.ref, 'refs/tags/')
+    env:
+      PROD_IMAGE_NAME: ${GITHUB_REPOSITORY}
+    needs: [check, unit-test]
+    name: Tagged release image
+    runs-on: ubuntu-latest
+    steps:
+      # Set up tag as version.
+      - name: Set tag on VERSION env var
+        run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF:10})
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: make build-image
+      - name: Docker login
+        run: docker login ${DOCKER_HOST} -u ${DOCKER_USER} -p ${DOCKER_TOKEN}
+        env:
+          DOCKER_HOST: ""
+          DOCKER_USER: slok
+          DOCKER_TOKEN: ${{secrets.DOCKER_HUB_TOKEN}}
+      - name: Publish image
+        run: make publish-image
+
+  tagged-release-binaries:
+    # Only on tags.
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [check, unit-test]
+    name: Tagged release binaries
+    runs-on: ubuntu-latest
+    steps:
+      # Set up tag as version.
+      - name: Set tag on VERSION env var
+        run: echo ::set-env name=VERSION::$(echo ${GITHUB_REF:10})
+      - uses: actions/checkout@v2
+
+      - name: Build binaries
+        run: |
+          mkdir -p ./bin
+          chmod -R 0777 ./bin
+          make build-all
+      - name: Upload binaries
+        uses: xresloader/upload-to-github-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: 'bin/*'
+          tags: true
+          draft: true

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ CHECK_CMD := ./scripts/check/check.sh
 DEV_IMAGE_NAME := slok/kahoy-dev
 PROD_IMAGE_NAME ?=  slok/kahoy
 
-DOCKER_RUN_CMD := docker run --env ostype=$(OSTYPE) -v ${PWD}:/src --rm -it ${DEV_IMAGE_NAME}
+DOCKER_RUN_CMD := docker run --env ostype=$(OSTYPE) -v ${PWD}:/src --rm ${DEV_IMAGE_NAME}
 BUILD_BINARY_CMD := VERSION=${VERSION} ./scripts/build/build.sh
+BUILD_BINARY_ALL_CMD := VERSION=${VERSION} ./scripts/build/build-all.sh
 BUILD_DEV_IMAGE_CMD := IMAGE=${DEV_IMAGE_NAME} DOCKER_FILE_PATH=./docker/dev/Dockerfile VERSION=latest ./scripts/build/build-image.sh
 BUILD_PROD_IMAGE_CMD := IMAGE=${PROD_IMAGE_NAME} DOCKER_FILE_PATH=./docker/prod/Dockerfile VERSION=${VERSION} ./scripts/build/build-image.sh
 PUBLISH_PROD_IMAGE_CMD := IMAGE=${PROD_IMAGE_NAME} VERSION=${VERSION} ./scripts/build/publish-image.sh
@@ -41,6 +42,9 @@ build-dev-image:  ## Builds the development docker image.
 
 build: build-dev-image ## Builds the production binary.
 	@$(DOCKER_RUN_CMD) /bin/sh -c '$(BUILD_BINARY_CMD)'
+
+build-all: build-dev-image ## Builds all archs production binaries.
+	@$(DOCKER_RUN_CMD) /bin/sh -c '$(BUILD_BINARY_ALL_CMD)'
 
 .PHONY: test
 test: build-dev-image  ## Runs unit test.

--- a/scripts/build/build-all.sh
+++ b/scripts/build/build-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+ostypes=("Linux" "Darwin" "Windows" "ARM64" "ARM")
+for ostype in "${ostypes[@]}"
+do
+	ostype="${ostype}" ./scripts/build/build.sh
+done


### PR DESCRIPTION
This PR adds the required steps to make releases from tags, this involves:

- Publish tagged docker images
- Publish tagged binaries in Github releases.