### PR TITLE
Remove git diff and move the logic to resource based diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+- Remove Git filtering in favor of generic filtering based on Kubernetes resource diff.
+- Add filtering based on changes at Kubernetes resource level.
+- Deprecate `--git-diff-filter` flag in favor of `--include-changes`.
+- Add `--include-changes` flag.
+
 ## [v1.0.0] - 2020-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Unlike other tools, Kahoy will adapt to your needs and not the other way around,
 
 - Simple, flexible, and lightweight.
 - Deploys a deletes Kubernetes resources.
-- Deploy anything, from a `Namespace`, `Deployment`... to a `CRD`.
+- Deploy anything, a `Namespace`, `Ingress`, `CRD`, domain apps (e.g `Deployment`+`service`)...
 - Plans what to delete or deploy based on two manifest states (old and new).
 - Garbage collection resources.
 - Load states from different sources (fs, git...).
 - Plans at Kubernetes resource level (not file/manifest level, not app/release level)
 - Different execution modes: Diff, Dry run...
 - Gitops ready (split commands, understands git repositories).
-- Use full syncs or partial syncs based on git diffs.
+- Use full syncs or partial syncs based on resource changes/diffs.
 - Deploy priorities.
 - Multiple filtering options (file paths, resource namespace, types...).
 - Uses Kubernetes >=v1.18 and server-side apply.
@@ -254,7 +254,7 @@ Having our manifest in a git repository in `./manifests` and being our default b
 ```bash
 kahoy apply \
     --dry-run \
-    --git-diff-filter \
+    --include-changes \
     --fs-new-manifests-path "./manifests"
 ```
 
@@ -278,7 +278,7 @@ So... in Kahoy:
 
 ```bash
 kahoy apply \
-    --git-diff-filter \
+    --include-changes \
     --git-before-commit-sha "${GIT_BEFORE_COMMIT_SHA}" \
     --fs-new-manifests-path "./manifests"
 ```
@@ -447,7 +447,9 @@ You can invoke Kahoy `N` times, one per environment.
 
 ### Partial and full syncs?
 
-Yes, partial syncs will apply only the changes from one git revision to another (`git diff`). full syncs apply all the repository.
+Partial syncs filter the resources that will apply based on the changes from one state to another (checks diffs between kubernetes resources in both states). Use `--include-changes` for partial syncs.
+
+Full syncs apply all the resources.
 
 Check this [Github actions example][github-actions-example] for more info.
 
@@ -463,8 +465,6 @@ This gives us the opportunity to track changes on our resources, applying a reli
 
 That's why Kahoy understands git, knows how to get two revisions, and compares the manifests that changed in those revisions, plan them and apply.
 
-Also having the ability to apply only the changes of a `git diff`, gives us a way of scaling better, more visibility and easy to integrate
-
 ### When to use paths mode?
 
 Kahoy understands git and most of the time you will not need it if you are using a repository. However, if you want to make everything yourself, using `paths` mode gives you full control. e.g:
@@ -473,9 +473,9 @@ Kahoy understands git and most of the time you will not need it if you are using
   - `new` manifests is the main repository
   - `old` manifests is a copy of `new` (`cp -r`) and checkout to a previous revision.
 - Use `--mode=paths` to pass those manifest paths (`--fs-old-manifests-path`, `--fs-new-manifests-path`) to the two repo paths in different states.
-- If you want to only apply on changes, use git diff to make N arguments with the option `--fs-include`.
+- If you want to only apply on changes, use `--include-changes`.
 
-Check an example [script][bash-git-example] that prepares a git diff file and the two manifests paths with the different revisions.
+Check an example [script][bash-git-example] that prepares two manifests paths with the different revisions.
 
 ### Env vars as options
 

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -76,19 +76,19 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	}
 
 	// Get resources from repositories.
-	currentRes, err := oldResourceRepo.ListResources(ctx, storage.ResourceListOpts{})
+	oldRes, err := oldResourceRepo.ListResources(ctx, storage.ResourceListOpts{})
 	if err != nil {
 		return fmt.Errorf("could not retrieve the list of current resources: %w", err)
 	}
 
-	expectedRes, err := newResourceRepo.ListResources(ctx, storage.ResourceListOpts{})
+	newRes, err := newResourceRepo.ListResources(ctx, storage.ResourceListOpts{})
 	if err != nil {
 		return fmt.Errorf("could not retrieve the list of expected resources: %w", err)
 	}
 
 	// Plan our actions/states.
-	planner := plan.NewPlanner(logger)
-	statePlan, err := planner.Plan(ctx, expectedRes.Items, currentRes.Items)
+	planner := plan.NewPlanner(false, logger)
+	statePlan, err := planner.Plan(ctx, oldRes.Items, newRes.Items)
 	if err != nil {
 		return fmt.Errorf("could not get a plan: %w", err)
 	}

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -35,16 +35,15 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	switch cmdConfig.Apply.Mode {
 	case ApplyModeGit:
 		oldRepo, newRepo, err := storagegit.NewRepositories(storagegit.RepositoriesConfig{
-			ExcludeRegex:         cmdConfig.Apply.ExcludeManifests,
-			IncludeRegex:         cmdConfig.Apply.IncludeManifests,
-			OldRelPath:           cmdConfig.Apply.ManifestsPathOld,
-			NewRelPath:           cmdConfig.Apply.ManifestsPathNew,
-			GitBeforeCommitSHA:   cmdConfig.Apply.GitBeforeCommit,
-			GitDefaultBranch:     cmdConfig.Apply.GitDefaultBranch,
-			GitDiffIncludeFilter: cmdConfig.Apply.GitDiffFilter,
-			KubernetesDecoder:    kubernetesSerializer,
-			AppConfig:            &globalConfig.AppConfig,
-			Logger:               logger,
+			ExcludeRegex:       cmdConfig.Apply.ExcludeManifests,
+			IncludeRegex:       cmdConfig.Apply.IncludeManifests,
+			OldRelPath:         cmdConfig.Apply.ManifestsPathOld,
+			NewRelPath:         cmdConfig.Apply.ManifestsPathNew,
+			GitBeforeCommitSHA: cmdConfig.Apply.GitBeforeCommit,
+			GitDefaultBranch:   cmdConfig.Apply.GitDefaultBranch,
+			KubernetesDecoder:  kubernetesSerializer,
+			AppConfig:          &globalConfig.AppConfig,
+			Logger:             logger,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create git based fs repos storage: %w", err)
@@ -87,7 +86,7 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	}
 
 	// Plan our actions/states.
-	planner := plan.NewPlanner(false, logger)
+	planner := plan.NewPlanner(cmdConfig.Apply.IncludeChanges, logger)
 	statePlan, err := planner.Plan(ctx, oldRes.Items, newRes.Items)
 	if err != nil {
 		return fmt.Errorf("could not get a plan: %w", err)

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -49,9 +49,9 @@ type CmdConfig struct {
 		ExcludeKubeTypeResources []string
 		GitBeforeCommit          string
 		GitDefaultBranch         string
-		GitDiffFilter            bool
 		Mode                     string
 		DryRun                   bool
+		IncludeChanges           bool
 	}
 }
 
@@ -72,19 +72,22 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 
 	// Apply command.
 	apply := app.Command(CmdArgApply, "Will take all the manifests in the directory and apply to a Kubernetes cluster.")
-	apply.Flag("kube-config", "kubernetes configuration configuration path.").Envar("KUBECONFIG").Default(kubeHome).StringVar(&c.Apply.KubeConfig)
-	apply.Flag("kube-context", "kubernetes configuration context.").StringVar(&c.Apply.KubeContext)
-	apply.Flag("diff", "diff instead of applying changes.").BoolVar(&c.Apply.DiffMode)
-	apply.Flag("dry-run", "execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
-	apply.Flag("mode", "selects how apply will select the state, load manifests... git needs to be executed from a git repository.").Default(ApplyModeGit).EnumVar(&c.Apply.Mode, ApplyModePaths, ApplyModeGit)
-	apply.Flag("fs-old-manifests-path", "kubernetes current manifests path.").Short('o').StringVar(&c.Apply.ManifestsPathOld)
-	apply.Flag("fs-new-manifests-path", "kubernetes expected manifests path.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
-	apply.Flag("fs-exclude", "regex to ignore manifest files and dirs. Can be repeated.").Short('e').StringsVar(&c.Apply.ExcludeManifests)
-	apply.Flag("fs-include", "regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").Short('i').StringsVar(&c.Apply.IncludeManifests)
-	apply.Flag("git-diff-filter", "excludes everything except the files changed in before-commit and HEAD git diff.").Short('f').BoolVar(&c.Apply.GitDiffFilter)
-	apply.Flag("git-before-commit-sha", "the git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)
-	apply.Flag("git-default-branch", "git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
-	apply.Flag("kube-exclude-type", "regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('a').StringsVar(&c.Apply.ExcludeKubeTypeResources)
+	apply.Flag("kube-config", "Kubernetes configuration configuration path.").Envar("KUBECONFIG").Default(kubeHome).StringVar(&c.Apply.KubeConfig)
+	apply.Flag("kube-context", "Kubernetes configuration context.").StringVar(&c.Apply.KubeContext)
+	apply.Flag("diff", "Diff instead of applying changes.").BoolVar(&c.Apply.DiffMode)
+	apply.Flag("dry-run", "Execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
+	apply.Flag("mode", "Selects how apply will select the state, load manifests... git needs to be executed from a git repository.").Default(ApplyModeGit).EnumVar(&c.Apply.Mode, ApplyModePaths, ApplyModeGit)
+	apply.Flag("fs-old-manifests-path", "Kubernetes current manifests path.").Short('o').StringVar(&c.Apply.ManifestsPathOld)
+	apply.Flag("fs-new-manifests-path", "Kubernetes expected manifests path.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
+	apply.Flag("fs-exclude", "Regex to ignore manifest files and dirs. Can be repeated.").Short('e').StringsVar(&c.Apply.ExcludeManifests)
+	apply.Flag("fs-include", "Regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").Short('i').StringsVar(&c.Apply.IncludeManifests)
+	apply.Flag("git-before-commit-sha", "The git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)
+	apply.Flag("git-default-branch", "Git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
+	apply.Flag("kube-exclude-type", "Regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('a').StringsVar(&c.Apply.ExcludeKubeTypeResources)
+	apply.Flag("include-changes", "Excludes all the resources without changes (old vs new states).").Short('f').BoolVar(&c.Apply.IncludeChanges)
+
+	// Deprecated flags.
+	apply.Flag("git-diff-filter", "DEPRECATED, use --include-changes.").Hidden().BoolVar(&c.Apply.IncludeChanges)
 
 	// Parse the commandline.
 	cmd, err := app.Parse(args)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -3,6 +3,8 @@ package plan
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+
 	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
 )
@@ -39,6 +41,8 @@ type planner struct {
 // NewPlanner returns a new planner.
 // The planner will take all the resources that exists on the new one, and delete
 // the ones that are not on the new one and are on the old one.
+// If `onlyOnDiff` is used, it will only add the ones that have changed and ignore the
+// ones that are the same.
 func NewPlanner(onlyOnDiff bool, logger log.Logger) Planner {
 	return planner{
 		onlyOnDiff: onlyOnDiff,
@@ -56,11 +60,22 @@ func (p planner) Plan(ctx context.Context, old []model.Resource, new []model.Res
 	states := []State{}
 
 	// Add the ones that we know need to exist.
-	for _, r := range newIdx {
+	for _, newRes := range newIdx {
+		// If we want to filter resources that didn't change, we need to check that if we had an old state,
+		// the resources have changed. In case they didn't change, we will ignore them.
+		// TODO(slok): If we start having more than one filter, move this to a filter processing chain style.
+		if p.onlyOnDiff {
+			oldRes, ok := oldIdx[newRes.ID]
+			if ok && !p.hasChanged(oldRes, newRes) {
+				resourceLogger(p.logger, newRes).Debugf("no changes between old and new state, ignoring resource from plan")
+				continue
+			}
+		}
+
 		existsQ++
 		states = append(states, State{
 			State:    ResourceStateExists,
-			Resource: r,
+			Resource: newRes,
 		})
 	}
 
@@ -91,4 +106,15 @@ func indexResources(rs []model.Resource) map[string]model.Resource {
 	}
 
 	return index
+}
+
+func (p planner) hasChanged(old, new model.Resource) bool {
+	return !equality.Semantic.Equalities.DeepEqual(old.K8sObject, new.K8sObject)
+}
+
+func resourceLogger(l log.Logger, r model.Resource) log.Logger {
+	return l.WithValues(log.Kv{
+		"resource-id":       r.ID,
+		"resource-group-id": r.GroupID,
+	})
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -7,18 +7,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
 	"github.com/slok/kahoy/internal/plan"
 )
 
+func newPod(name string, containerNames []string) model.K8sObject {
+	type tm = map[string]interface{}
+
+	containers := []tm{}
+	for _, cName := range containerNames {
+		containers = append(containers, tm{
+			"name": cName,
+		})
+	}
+
+	return &unstructured.Unstructured{
+		Object: tm{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": tm{
+				"name":      name,
+				"namespace": "test",
+			},
+			"spec": tm{
+				"containers": containers,
+			},
+		},
+	}
+}
+
 func TestPlannerPlan(t *testing.T) {
 	tests := map[string]struct {
-		oldRes   []model.Resource
-		newRes   []model.Resource
-		expState []plan.State
-		expErr   error
+		onlyOnDiff bool
+		oldRes     []model.Resource
+		newRes     []model.Resource
+		expState   []plan.State
+		expErr     error
 	}{
 		"Without old and new resources, should plan empty list of states.": {
 			expState: []plan.State{},
@@ -26,6 +53,23 @@ func TestPlannerPlan(t *testing.T) {
 
 		"Without old and with new resources, should plan list withouth missing states.": {
 			oldRes: []model.Resource{},
+			newRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateExists},
+			},
+		},
+
+		"Without old and with new resources, using only diff changes flag, should plan list withouth missing states.": {
+			onlyOnDiff: true,
+			oldRes:     []model.Resource{},
 			newRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
@@ -61,7 +105,50 @@ func TestPlannerPlan(t *testing.T) {
 			},
 		},
 
+		"With same old and new resources, using only diff changes flag, should plan list with onthe the resources that changed.": {
+			onlyOnDiff: true,
+			oldRes: []model.Resource{
+				{ID: "test0", K8sObject: newPod("test0", []string{"c1", "c2", "c3"})},
+				{ID: "test1", K8sObject: newPod("test1", []string{"c1", "c2", "c3"})},
+				{ID: "test2", K8sObject: newPod("test2", []string{"c1", "c2", "c3"})},
+				{ID: "test3", K8sObject: newPod("test3", []string{"c1", "c2", "c3"})},
+				{ID: "test4", K8sObject: newPod("test4", []string{"c1", "c2", "c3"})},
+				{ID: "test5", K8sObject: newPod("test5", []string{"c1", "c2", "c3"})},
+			},
+			newRes: []model.Resource{
+				{ID: "test0", K8sObject: newPod("test0", nil)},
+				{ID: "test1", K8sObject: newPod("test1", []string{"c2", "c3"})},
+				{ID: "test2", K8sObject: newPod("test2", []string{"c1", "c2", "c3"})},
+				{ID: "test3", K8sObject: newPod("test3", []string{"c1", "c2", "c3", "c4"})},
+				{ID: "test4", K8sObject: newPod("test4", []string{"c3", "c2", "c1"})},
+				{ID: "test5", K8sObject: newPod("test5", []string{"c1", "c2", "c3"})},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0", K8sObject: newPod("test0", nil)}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1", K8sObject: newPod("test1", []string{"c2", "c3"})}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test3", K8sObject: newPod("test3", []string{"c1", "c2", "c3", "c4"})}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test4", K8sObject: newPod("test4", []string{"c3", "c2", "c1"})}, State: plan.ResourceStateExists},
+			},
+		},
+
 		"With deleted in the new resources, should plan list with missing states.": {
+			oldRes: []model.Resource{
+				{ID: "test0"},
+				{ID: "test1"},
+				{ID: "test2"},
+				{ID: "test3"},
+			},
+			newRes: []model.Resource{},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test2"}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test3"}, State: plan.ResourceStateMissing},
+			},
+		},
+
+		"With deleted in the new resources, using only diff changes flag, should plan list with missing states.": {
+			onlyOnDiff: true,
 			oldRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
@@ -97,13 +184,37 @@ func TestPlannerPlan(t *testing.T) {
 				{Resource: model.Resource{ID: "test4"}, State: plan.ResourceStateExists},
 			},
 		},
+
+		"With some deleted and some new in the new resources, using only diff changes flag, should plan list with missing states and changes.": {
+			onlyOnDiff: true,
+			oldRes: []model.Resource{
+				{ID: "test0", K8sObject: newPod("test0", []string{"c1", "c2", "c3"})},
+				{ID: "test1", K8sObject: newPod("test1", []string{"c1", "c2", "c3"})},
+				{ID: "test2", K8sObject: newPod("test2", []string{"c1", "c2", "c3"})},
+				{ID: "test3", K8sObject: newPod("test3", []string{"c1", "c2", "c3"})},
+				{ID: "test4", K8sObject: newPod("test4", []string{"c1", "c2", "c3"})},
+				{ID: "test5", K8sObject: newPod("test5", []string{"c1", "c2", "c3"})},
+			},
+			newRes: []model.Resource{
+				{ID: "test0", K8sObject: newPod("test0", []string{"c1", "c2", "c3", "c4"})},
+				{ID: "test2", K8sObject: newPod("test2", []string{"c1", "c2", "c3"})},
+				{ID: "test4", K8sObject: newPod("test4", []string{"c1", "c2", "c3"})},
+				{ID: "test5", K8sObject: newPod("test5", []string{"c3", "c1", "c2"})},
+			},
+			expState: []plan.State{
+				{Resource: model.Resource{ID: "test0", K8sObject: newPod("test0", []string{"c1", "c2", "c3", "c4"})}, State: plan.ResourceStateExists},
+				{Resource: model.Resource{ID: "test1", K8sObject: newPod("test1", []string{"c1", "c2", "c3"})}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test3", K8sObject: newPod("test3", []string{"c1", "c2", "c3"})}, State: plan.ResourceStateMissing},
+				{Resource: model.Resource{ID: "test5", K8sObject: newPod("test5", []string{"c3", "c1", "c2"})}, State: plan.ResourceStateExists},
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			p := plan.NewPlanner(false, log.Noop)
+			p := plan.NewPlanner(test.onlyOnDiff, log.Noop)
 			gotState, err := p.Plan(context.TODO(), test.oldRes, test.newRes)
 
 			if test.expErr != nil {

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -15,18 +15,18 @@ import (
 
 func TestPlannerPlan(t *testing.T) {
 	tests := map[string]struct {
-		currentRes  []model.Resource
-		expectedRes []model.Resource
-		expState    []plan.State
-		expErr      error
+		oldRes   []model.Resource
+		newRes   []model.Resource
+		expState []plan.State
+		expErr   error
 	}{
-		"Without current and expected resources, should plan empty list of states.": {
+		"Without old and new resources, should plan empty list of states.": {
 			expState: []plan.State{},
 		},
 
-		"Without current and with expected resources, should plan list withouth missing states.": {
-			currentRes: []model.Resource{},
-			expectedRes: []model.Resource{
+		"Without old and with new resources, should plan list withouth missing states.": {
+			oldRes: []model.Resource{},
+			newRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
 				{ID: "test2"},
@@ -40,14 +40,14 @@ func TestPlannerPlan(t *testing.T) {
 			},
 		},
 
-		"With same current and expected resources, should plan list withouth missing states.": {
-			currentRes: []model.Resource{
+		"With same old and new resources, should plan list withouth missing states.": {
+			oldRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
 				{ID: "test2"},
 				{ID: "test3"},
 			},
-			expectedRes: []model.Resource{
+			newRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
 				{ID: "test2"},
@@ -61,14 +61,14 @@ func TestPlannerPlan(t *testing.T) {
 			},
 		},
 
-		"With deleted in the expected resources, should plan list with missing states.": {
-			currentRes: []model.Resource{
+		"With deleted in the new resources, should plan list with missing states.": {
+			oldRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
 				{ID: "test2"},
 				{ID: "test3"},
 			},
-			expectedRes: []model.Resource{},
+			newRes: []model.Resource{},
 			expState: []plan.State{
 				{Resource: model.Resource{ID: "test0"}, State: plan.ResourceStateMissing},
 				{Resource: model.Resource{ID: "test1"}, State: plan.ResourceStateMissing},
@@ -77,14 +77,14 @@ func TestPlannerPlan(t *testing.T) {
 			},
 		},
 
-		"With some deleted and some new in the expected resources, should plan list with missing states.": {
-			currentRes: []model.Resource{
+		"With some deleted and some new in the new resources, should plan list with missing states.": {
+			oldRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test1"},
 				{ID: "test2"},
 				{ID: "test3"},
 			},
-			expectedRes: []model.Resource{
+			newRes: []model.Resource{
 				{ID: "test0"},
 				{ID: "test2"},
 				{ID: "test4"},
@@ -103,8 +103,8 @@ func TestPlannerPlan(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			p := plan.NewPlanner(log.Noop)
-			gotState, err := p.Plan(context.TODO(), test.expectedRes, test.currentRes)
+			p := plan.NewPlanner(false, log.Noop)
+			gotState, err := p.Plan(context.TODO(), test.oldRes, test.newRes)
 
 			if test.expErr != nil {
 				assert.True(errors.Is(err, test.expErr))

--- a/internal/resource/process/kubemeta_test.go
+++ b/internal/resource/process/kubemeta_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/slok/kahoy/internal/resource/process"
 )
 
-type tm map[string]interface{}
-
 func newResource(kAPIVersion, kType, ns, name string) model.Resource {
+	type tm = map[string]interface{}
+
 	return model.Resource{
 		K8sObject: &unstructured.Unstructured{
 			Object: tm{

--- a/internal/storage/git/factory_test.go
+++ b/internal/storage/git/factory_test.go
@@ -273,38 +273,6 @@ func TestNewRepositories(t *testing.T) {
 			},
 			expErr: true,
 		},
-
-		"If git diff filter is used, it should get a diff patch between before-commit and HEAD commits.": {
-			config: git.RepositoriesConfig{
-				AppConfig:            &model.AppConfig{},
-				OldRelPath:           "./manifests",
-				NewRelPath:           "./manifests",
-				GitBeforeCommitSHA:   "cfd490e528d1c49b093cee3818cb63e2e0e8f3ef",
-				GitDiffIncludeFilter: true,
-			},
-			mock: func(mOld, mNew *gitmock.GoGitRepoClient) {
-				oldFs, newFs := memfs.New(), memfs.New()
-				_, _ = oldFs.Create("/manifests")
-				_, _ = newFs.Create("/manifests")
-				mOld.On("FileSystem").Once().Return(oldFs, nil)
-				mNew.On("FileSystem").Once().Return(newFs, nil)
-
-				mOld.On("Checkout", mock.Anything).Once().Return(nil)
-
-				beforeRef := plumbing.NewReferenceFromStrings("", "448aa55561b85897120f611e2da67ac2d0e7a8bf")
-				mOld.On("Head").Once().Return(beforeRef, nil)
-				headRef := plumbing.NewReferenceFromStrings("", "f69577b7a14bb6d112188cd75029f4aa6605b944")
-				mNew.On("Head").Once().Return(headRef, nil)
-
-				// Check diff.
-				beforeCommit := &object.Commit{Hash: beforeRef.Hash()}
-				mNew.On("CommitObject", beforeRef.Hash()).Once().Return(beforeCommit, nil)
-				headCommit := &object.Commit{Hash: headRef.Hash()}
-				mNew.On("CommitObject", headRef.Hash()).Once().Return(headCommit, nil)
-				mNew.On("Patch", beforeCommit, headCommit).Once().Return(&object.Patch{}, nil)
-
-			},
-		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Closes #82 

This PR moves the changed based filtering to the resource domain level, this means:

- Less optimal (git storage will load all resources).
- More generic: Now we don't depend on the storage implementations to apply only the changed resources
- Simpler: Check if an old resource is the same as the new one.

More stuff: 

- We have deprecated the `--git-diff-filter` flag in favor of `--include-changes`.
- For the changes check we use [apimachinery DeepEqual](https://godoc.org/k8s.io/apimachinery/third_party/forked/golang/reflect#Equalities.DeepEqual) on K8s resource
