### PR TITLE
Add Kubernetes style label selector filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## [unreleased]
 
-- Remove Git filtering in favor of generic filtering based on Kubernetes resource diff.
-- Add filtering based on changes at Kubernetes resource level.
+### Added
+
+- Optional filter apply/delete plan based on K8s resources that had changes from old to new state using `--include-changes` flag.
+- Optional filter for resources using Kubernetes stantand label selectors using `--kube-include-label` flag.
+
+### Changed
+
 - Deprecate `--git-diff-filter` flag in favor of `--include-changes`.
-- Add `--include-changes` flag.
+
+### Removed
+
+- Git filtering in favor of generic filtering based on Kubernetes resource diff.
 
 ## [v1.0.0] - 2020-08-31
 

--- a/README.md
+++ b/README.md
@@ -515,8 +515,8 @@ At file level you have `--fs-include` and `--fs-exclude`, these exclude or inclu
 
 At Kubernetes resource level you have others:
 
-- `--kube-exclude-type`: Exclude based on Kubernetes type regex (e.g: `apps/*/Deployment, v1/Pod`)
-- TODO more of them
+- `--kube-exclude-type`: Exclude based on Kubernetes type regex (e.g: `apps/*/Deployment`, `v1/Pod`...).
+- `--kube-include-label`: Kubenretes style selector that will select only the resources that match the label selectos (e.g: `app=myapp,component!=database`)
 
 ### Github actions integration
 

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -47,6 +47,7 @@ type CmdConfig struct {
 		ExcludeManifests         []string
 		IncludeManifests         []string
 		ExcludeKubeTypeResources []string
+		KubeLabelSelector        string
 		GitBeforeCommit          string
 		GitDefaultBranch         string
 		Mode                     string
@@ -84,6 +85,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("git-before-commit-sha", "The git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)
 	apply.Flag("git-default-branch", "Git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
 	apply.Flag("kube-exclude-type", "Regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('a').StringsVar(&c.Apply.ExcludeKubeTypeResources)
+	apply.Flag("kube-include-label", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)").Short('l').StringVar(&c.Apply.KubeLabelSelector)
 	apply.Flag("include-changes", "Excludes all the resources without changes (old vs new states).").Short('f').BoolVar(&c.Apply.IncludeChanges)
 
 	// Deprecated flags.

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,10 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/fatih/color v1.9.0
-	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/sirupsen/logrus v1.6.0
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/apimachinery v0.18.8

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680 h1:ZktWZesgun21uEDrwW7iEV1zPCGQldM2atlJZ3TdvVM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -112,9 +114,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
-github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/resource/process/kubemeta.go
+++ b/internal/resource/process/kubemeta.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
 )
@@ -62,9 +64,48 @@ func NewExcludeKubeTypeProcessor(kubeTypeRegex []string, logger log.Logger) (Res
 	}), nil
 }
 
+// NewKubeSelectorProcessor returns a new Resource processor that will exclude (remove)
+// from the received resources, the ones that don't match with the received Kubernetes
+// label selector.
+func NewKubeSelectorProcessor(kubeSelector string, logger log.Logger) (ResourceProcessor, error) {
+	logger = logger.WithValues(log.Kv{"app-svc": "process.KubeSelectorProcessor"})
+
+	// Create label selectors.
+	selectors, err := labels.ParseToRequirements(kubeSelector)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse Kubernetes label selector %w", err)
+	}
+
+	return ResourceProcessorFunc(func(ctx context.Context, resources []model.Resource) ([]model.Resource, error) {
+		newRes := []model.Resource{}
+
+		for _, r := range resources {
+			resLabels := r.K8sObject.GetLabels()
+			if !matchSelector(selectors, resLabels) {
+				resourceLogger(logger, r).Debugf("resource ignored")
+				continue
+			}
+			newRes = append(newRes, r)
+		}
+
+		return newRes, nil
+	}), nil
+}
+
 func resourceLogger(l log.Logger, r model.Resource) log.Logger {
 	return l.WithValues(log.Kv{
 		"resource-id":       r.ID,
 		"resource-group-id": r.GroupID,
 	})
+}
+
+func matchSelector(selectors []labels.Requirement, resLabels map[string]string) bool {
+	labelSet := labels.Set(resLabels)
+	for _, selector := range selectors {
+		if !selector.Matches(labelSet) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
Closes #48 

This PR adds the ability to use a Kubernetes style selector to include the wanted resources based on the selector.


This can be helpful to ignore resources on:

- Big repository with lots of resources.
- Test. 
- Deployments based on different steps.
- progressive usage of Kahoy.