### PR TITLE
Add Kubernetes style label selector for annotation based filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 ## [unreleased]
 
+Breaking: `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-include-annotation` is `-a` short flag.
+
 ### Added
 
 - Optional filter apply/delete plan based on K8s resources that had changes from old to new state using `--include-changes` flag.
-- Optional filter for resources using Kubernetes stantand label selectors using `--kube-include-label` flag.
+- Optional label based filter for resources using Kubernetes standard label selectors using `--kube-include-label` flag.
+- Optional annotation filter for resources using Kubernetes standard label selectors using `--kube-include-annotation` flag.
 
 ### Changed
 
 - Deprecate `--git-diff-filter` flag in favor of `--include-changes`.
+- `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-include-annotation` is `-a` short flag.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -516,7 +516,8 @@ At file level you have `--fs-include` and `--fs-exclude`, these exclude or inclu
 At Kubernetes resource level you have others:
 
 - `--kube-exclude-type`: Exclude based on Kubernetes type regex (e.g: `apps/*/Deployment`, `v1/Pod`...).
-- `--kube-include-label`: Kubenretes style selector that will select only the resources that match the label selectos (e.g: `app=myapp,component!=database`)
+- `--kube-include-label`: Kubernetes style selector that will select only the resources that match the label selector (e.g: `app=myapp,component!=database,env`)
+- `--kube-include-annotation`: Kubernetes style selector that will select only the resources that match the annotation selector (e.g: `app=myapp,component!=database`)
 
 ### Github actions integration
 

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -48,6 +48,7 @@ type CmdConfig struct {
 		IncludeManifests         []string
 		ExcludeKubeTypeResources []string
 		KubeLabelSelector        string
+		KubeAnnotationSelector   string
 		GitBeforeCommit          string
 		GitDefaultBranch         string
 		Mode                     string
@@ -84,8 +85,9 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("fs-include", "Regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").Short('i').StringsVar(&c.Apply.IncludeManifests)
 	apply.Flag("git-before-commit-sha", "The git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)
 	apply.Flag("git-default-branch", "Git repository default branch. Used to search common parent (default-branch and HEAD) when 'before-commit' not provided. Only supports local branches (no remote branches, tags, hashes...).").Default("master").StringVar(&c.Apply.GitDefaultBranch)
-	apply.Flag("kube-exclude-type", "Regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('a').StringsVar(&c.Apply.ExcludeKubeTypeResources)
+	apply.Flag("kube-exclude-type", "Regex to ignore Kubernetes resources by api version and type (apps/v1/Deployment, v1/Pod...). Can be repeated.").Short('t').StringsVar(&c.Apply.ExcludeKubeTypeResources)
 	apply.Flag("kube-include-label", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)").Short('l').StringVar(&c.Apply.KubeLabelSelector)
+	apply.Flag("kube-include-annotation", "Selector (annotation query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)").Short('a').StringVar(&c.Apply.KubeAnnotationSelector)
 	apply.Flag("include-changes", "Excludes all the resources without changes (old vs new states).").Short('f').BoolVar(&c.Apply.IncludeChanges)
 
 	// Deprecated flags.


### PR DESCRIPTION
Closes #49 

This PR is similar to #85, it filters the resources using a Kubernetes style label selector, against the resource annotations.

It has a breaking change on the short command `-a`, now this will be used for the annotation filtering instead of the type filtering.

This breaking change force us releasing v2.x