### PR TITLE
Add metav1.List decoding on YAML Kubernetes serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking: `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-in
 - Optional filter apply/delete plan based on K8s resources that had changes from old to new state using `--include-changes` flag.
 - Optional label based filter for resources using Kubernetes standard label selectors using `--kube-include-label` flag.
 - Optional annotation filter for resources using Kubernetes standard label selectors using `--kube-include-annotation` flag.
+- Load `metav1.List` YAML resources as individual resources.
 
 ### Changed
 


### PR DESCRIPTION
Closes #88 

This PR adds support for decoding [`metav1.List`] objects. It checks if the decoded objects are an [`Unstructured`] or [`UnstructuredList`], in the case is the second one it will get all the `Items` and treat them as regular [`Unstructured`] resources.

[`metav1.List`]: https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#List
[`UnstructuredList`]: https://godoc.org/github.com/kubernetes/apimachinery/pkg/apis/meta/v1/unstructured#UnstructuredList
[`Unstructured`]: https://godoc.org/github.com/kubernetes/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured