### PR TITLE
Capture OS signal correctly and stop the execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [unreleased]
 
-Breaking: `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-include-annotation` is `-a` short flag.
+### Breaking
+
+- `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-include-annotation` is `-a` short flag.
 
 ### Added
 
@@ -19,6 +21,9 @@ Breaking: `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-in
 - On Diff, deleted resources now show the real fields and resource the server will delete (before we didn't check the server state).
 - Fix YAML failing on load when YAML file was multiresource and had files only with comments.
 - Fix using current directory as the manifests path, loads all resources as root group.
+- Capture correctly OS sigansl and stop safely command execution.
+- Batch executions stop in the different batch executions if context is cancelled.
+- Group wait now stops if the context is cancelled.
 
 ### Removed
 

--- a/cmd/kahoy/main.go
+++ b/cmd/kahoy/main.go
@@ -113,7 +113,7 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 				return cmd(ctx, *config, gConfig)
 			},
 			func(_ error) {
-				logger.Infof("stopping cmd execution")
+				logger.Debugf("stopping cmd execution")
 				cancel()
 			},
 		)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-git/go-billy/v5 v5.0.0
 	github.com/go-git/go-git/v5 v5.1.0
+	github.com/oklog/run v1.1.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/internal/resource/manage/wait/wait.go
+++ b/internal/resource/manage/wait/wait.go
@@ -25,8 +25,10 @@ const stdTM = stdTimeManager(0)
 var _ TimeManager = stdTM
 
 func (stdTimeManager) Sleep(ctx context.Context, d time.Duration) {
-	// TODO(slok): Check context and cancel execution if required.
-	time.Sleep(d)
+	select {
+	case <-ctx.Done():
+	case <-time.After(d):
+	}
 }
 
 // ManagerConfig is the configuration of the Wait manager.


### PR DESCRIPTION
Fixes #98 

This PR adds multiple parts to be able to cancel the app execution based on OS signals:

- Capture OS signals and stop cmd execution using context.
- Waiting manager sleep, will cancel if `context` is cancelled.
- Batch manager will cancel batch executions if `context` is cancelled.