### PR TITLE
Add the ability to set  fs-exclude and fs-include flags configuration in the kahoy app configuration file as an alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Optional annotation filter for resources using Kubernetes standard label selectors using `--kube-include-annotation` flag.
 - Load `metav1.List` YAML resources as individual resources.
 - Allow groups waiting specific time after apply.
+- Add `fs-include` and `fs-exclude` arg options to kahoy app global configuration file as an alternative.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -361,24 +361,14 @@ Kahoy knows how to manage priorities. By default it will batch all the manifests
 you would have `kahoy.yml` on your repo root (or any other path and use `--config-file`), with the group options:
 
 ```yaml
-# Version of the configuration format.
 version: v1
 
-# Groups configuration.
 groups:
-  # Represented by the group ID
   - id: crd
-    # Priority of the group (by default is 1000). Applied in asc order.
     priority: 200
-    # Wait options.
-    wait:
-      # The time will wait after being applied (Ts, Tm, Th format).
-      duration: 5s
 
   - id: ns
     priority: 100
-    wait:
-      duration: 10s
 
   - id: system/roles
     priority: 300
@@ -540,7 +530,7 @@ At Kubernetes resource level you have others:
 
 - `--kube-exclude-type`: Exclude based on Kubernetes type regex (e.g: `apps/*/Deployment`, `v1/Pod`...).
 - `--kube-include-label`: Kubernetes style selector that will select only the resources that match the label selector (e.g: `app=myapp,component!=database,env`)
-- `--kube-include-annotation`: Kubernetes style selector that will select only the resources that match the annotation selector (e.g: `app=myapp,component!=database`)
+- `--kube-include-annotation`: Kubernetes style selector that will select only the resources that match the annotation selector (e.g: `app=myapp,component!=database,!non-wanted-key`)
 
 ### Why so many filtering options?
 
@@ -581,12 +571,37 @@ Check this [Github actions example][github-actions-example] for more info.
 Kahoy accepts a configuration file (by default `./kahoy.yml`) to set options, at this moment these are the options:
 
 ```yaml
+# Version of the configuration format.
 version: v1
+
+# File system configuration.
+fs:
+  # Exclude regex for file paths (same as `--fs-exclude`, can be used both).
+  exclude:
+    - prometheus/secrets
+    - secret*
+  # Include regex for file paths (same as `--fs-include`, can be used both).
+  include:
+    - apps/
 
 # List of groups configuration.
 groups:
-  - id: crd # Identifies by group ID.
-    priority: 200 # Adds apply priority to all the resources in a group (by default `1000`).
+  # Represented by the group ID
+  - id: crd
+    # Priority of the group (by default is 1000). Applied in asc order.
+    priority: 200
+    # Wait options.
+    wait:
+      # The time will wait after being applied (Ts, Tm, Th format).
+      duration: 5s
+
+  - id: ns
+    priority: 100
+    wait:
+      duration: 10s
+
+  - id: system/roles
+    priority: 300
 ```
 
 ## :tophat: Alternatives

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -30,6 +30,10 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	// Create YAML serializer.
 	kubernetesSerializer := kubernetes.NewYAMLObjectSerializer(logger)
 
+	// Aggregate options (cmd flags + kahoy config files).
+	fsExclude := append(cmdConfig.Apply.ExcludeManifests, globalConfig.AppConfig.Fs.Exclude...)
+	fsInclude := append(cmdConfig.Apply.IncludeManifests, globalConfig.AppConfig.Fs.Include...)
+
 	var (
 		oldResourceRepo, newResourceRepo storage.ResourceRepository
 		newGroupRepo                     storage.GroupRepository
@@ -37,8 +41,8 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	switch cmdConfig.Apply.Mode {
 	case ApplyModeGit:
 		oldRepo, newRepo, err := storagegit.NewRepositories(storagegit.RepositoriesConfig{
-			ExcludeRegex:       cmdConfig.Apply.ExcludeManifests,
-			IncludeRegex:       cmdConfig.Apply.IncludeManifests,
+			ExcludeRegex:       fsExclude,
+			IncludeRegex:       fsInclude,
 			OldRelPath:         cmdConfig.Apply.ManifestsPathOld,
 			NewRelPath:         cmdConfig.Apply.ManifestsPathNew,
 			GitBeforeCommitSHA: cmdConfig.Apply.GitBeforeCommit,
@@ -57,8 +61,8 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 
 	case ApplyModePaths:
 		oldRepo, newRepo, err := storagefs.NewRepositories(storagefs.RepositoriesConfig{
-			ExcludeRegex:      cmdConfig.Apply.ExcludeManifests,
-			IncludeRegex:      cmdConfig.Apply.IncludeManifests,
+			ExcludeRegex:      fsExclude,
+			IncludeRegex:      fsInclude,
 			OldPath:           cmdConfig.Apply.ManifestsPathOld,
 			NewPath:           cmdConfig.Apply.ManifestsPathNew,
 			KubernetesDecoder: kubernetesSerializer,

--- a/internal/configuration/v1.go
+++ b/internal/configuration/v1.go
@@ -12,7 +12,10 @@ import (
 
 type jsonV1 struct {
 	Version string `json:"version"`
-
+	Fs      struct {
+		Exclude []string `json:"exclude"`
+		Include []string `json:"include"`
+	} `json:"fs"`
 	Groups []struct {
 		ID       string `json:"id"`
 		Priority *int   `json:"priority,omitempty"`
@@ -23,6 +26,12 @@ type jsonV1 struct {
 }
 
 func (j jsonV1) toModel() (*model.AppConfig, error) {
+	// Map fs.
+	fs := model.FsConfig{
+		Exclude: j.Fs.Exclude,
+		Include: j.Fs.Include,
+	}
+
 	// Map groups.
 	groups := map[string]model.GroupConfig{}
 	for _, g := range j.Groups {
@@ -48,6 +57,7 @@ func (j jsonV1) toModel() (*model.AppConfig, error) {
 	}
 
 	return &model.AppConfig{
+		Fs:     fs,
 		Groups: groups,
 	}, nil
 }

--- a/internal/configuration/v1_test.go
+++ b/internal/configuration/v1_test.go
@@ -16,7 +16,6 @@ func intVal(i int) *int {
 }
 
 func TestYAMLV1(t *testing.T) {
-
 	tests := map[string]struct {
 		data      string
 		expConfig model.AppConfig
@@ -35,6 +34,13 @@ func TestYAMLV1(t *testing.T) {
 		"Correct config file should be loaded correctly.": {
 			data: `
 version: v1
+fs:
+  exclude:
+    - a/test/*
+    - b/*/test
+  include:
+    - c/test/*
+    - /d/
 groups:
   - id: "prometheus/crd"
     priority: 50
@@ -42,6 +48,16 @@ groups:
       duration: 15s
 `,
 			expConfig: model.AppConfig{
+				Fs: model.FsConfig{
+					Exclude: []string{
+						"a/test/*",
+						"b/*/test",
+					},
+					Include: []string{
+						"c/test/*",
+						"/d/",
+					},
+				},
 				Groups: map[string]model.GroupConfig{
 					"prometheus/crd": {
 						Priority: intVal(50),

--- a/internal/model/app.go
+++ b/internal/model/app.go
@@ -7,8 +7,16 @@ import (
 
 // AppConfig is the configuration of the app.
 type AppConfig struct {
+	// Fs is the Fs configuration.
+	Fs FsConfig
 	// Group configuration by ID
 	Groups map[string]GroupConfig
+}
+
+// FsConfig is the Fs configuration.
+type FsConfig struct {
+	Exclude []string
+	Include []string
 }
 
 // GroupConfig is the group configuration.

--- a/tests/manual/kahoy.yml
+++ b/tests/manual/kahoy.yml
@@ -1,5 +1,10 @@
 version: v1
 
+# Fs configuration.
+fs:
+  exclude:
+    - wrong.yaml
+
 # Groups configuration.
 groups:
   - id: ns

--- a/tests/manual/manifests-all/wrong.yaml
+++ b/tests/manual/manifests-all/wrong.yaml
@@ -1,0 +1,1 @@
+this should error on load


### PR DESCRIPTION
Closes #103 

This PR adds the ability to set up fs exclude and include options in Kahoy's configuration file.