### PR TITLE
Improve excternal command execution stdout/sterr output using app logger

### DIFF
--- a/internal/resource/manage/kubectl/diff_test.go
+++ b/internal/resource/manage/kubectl/diff_test.go
@@ -1,6 +1,7 @@
 package kubectl_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -25,6 +26,8 @@ func expCmdMatcher(expArgs []string, expInput string) func(cmd *exec.Cmd) bool {
 		if err != nil {
 			return false
 		}
+		// Write back in case further checks are made.
+		cmd.Stdin = bytes.NewReader(data)
 
 		if string(data) != expInput {
 			return false

--- a/internal/resource/manage/kubectl/helpers.go
+++ b/internal/resource/manage/kubectl/helpers.go
@@ -2,15 +2,21 @@ package kubectl
 
 import (
 	"context"
+	"io"
 	"os/exec"
 
 	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
 )
 
-// CmdRunner knows how to run exec.Cmd commands.
+// CmdRunner knows how to run exec.Cmd commands. Normally we use this
+// so we can mock the cmd run without the need to wait for the streams
+// capture the command executed...
 type CmdRunner interface {
-	Run(*exec.Cmd) error
+	Run(c *exec.Cmd) error
+	Start(c *exec.Cmd) error
+	Wait(c *exec.Cmd) error
+	StdoutPipe(c *exec.Cmd) (io.ReadCloser, error)
 }
 
 //go:generate mockery --case underscore --output kubectlmock --outpkg kubectlmock --name CmdRunner
@@ -19,9 +25,28 @@ type stdCmdRunner struct {
 	logger log.Logger
 }
 
+func newStdCmdRunner(logger log.Logger) CmdRunner {
+	return stdCmdRunner{
+		logger: logger.WithValues(log.Kv{"app-svc": "kubectl.stdCmdRunner"}),
+	}
+}
+
 func (s stdCmdRunner) Run(c *exec.Cmd) error {
 	s.logger.Debugf("running cmd: '%s'", c)
 	return c.Run()
+}
+
+func (s stdCmdRunner) Start(c *exec.Cmd) error {
+	s.logger.Debugf("running cmd: '%s'", c)
+	return c.Start()
+}
+
+func (s stdCmdRunner) Wait(c *exec.Cmd) error {
+	return c.Wait()
+}
+
+func (s stdCmdRunner) StdoutPipe(c *exec.Cmd) (io.ReadCloser, error) {
+	return c.StdoutPipe()
 }
 
 // K8sObjectEncoder knows how to encode K8s objects into Raw Kubernetes compatible formats.

--- a/internal/resource/manage/kubectl/kubectl_test.go
+++ b/internal/resource/manage/kubectl/kubectl_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/slok/kahoy/internal/resource/manage/kubectl/kubectlmock"
 )
 
+type nopReaderCloser int
+
+const nopRC = nopReaderCloser(0)
+
+func (nopReaderCloser) Read(p []byte) (n int, err error) { return len(p), err }
+func (nopReaderCloser) Close() error                     { return nil }
+
 func TestManagerApply(t *testing.T) {
 	tests := map[string]struct {
 		config    kubectl.ManagerConfig
@@ -43,7 +50,10 @@ func TestManagerApply(t *testing.T) {
 					[]string{"kubectl", "apply", "--force-conflicts=true", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -59,7 +69,9 @@ func TestManagerApply(t *testing.T) {
 			resources: []model.Resource{{Name: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, nil)
-				mc.On("Run", mock.Anything).Once().Return(errors.New("whatever"))
+				mc.On("StdoutPipe", mock.Anything).Once().Return(nopRC, nil)
+				mc.On("Start", mock.Anything).Once().Return(errors.New("whatever"))
+				mc.On("Wait", mock.Anything).Once().Return(nil)
 			},
 			expErr: true,
 		},
@@ -76,7 +88,9 @@ func TestManagerApply(t *testing.T) {
 					[]string{"whatever", "apply", "--force-conflicts=true", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -92,7 +106,9 @@ func TestManagerApply(t *testing.T) {
 					[]string{"kubectl", "apply", "--context", "whatever", "--force-conflicts=true", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -108,7 +124,9 @@ func TestManagerApply(t *testing.T) {
 					[]string{"kubectl", "apply", "--kubeconfig", "whatever", "--force-conflicts=true", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -124,7 +142,9 @@ func TestManagerApply(t *testing.T) {
 					[]string{"kubectl", "apply", "--force-conflicts=false", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -140,7 +160,9 @@ func TestManagerApply(t *testing.T) {
 					[]string{"kubectl", "apply", "--force-conflicts=true", "--field-manager", "whatever", "--server-side=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 	}
@@ -203,7 +225,9 @@ func TestManagerDelete(t *testing.T) {
 					[]string{"kubectl", "delete", "--ignore-not-found=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -219,7 +243,9 @@ func TestManagerDelete(t *testing.T) {
 			resources: []model.Resource{{Name: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, nil)
-				mc.On("Run", mock.Anything).Once().Return(errors.New("whatever"))
+				mc.On("StdoutPipe", mock.Anything).Once().Return(nopRC, nil)
+				mc.On("Start", mock.Anything).Once().Return(errors.New("whatever"))
+				mc.On("Wait", mock.Anything).Once().Return(nil)
 			},
 			expErr: true,
 		},
@@ -236,7 +262,9 @@ func TestManagerDelete(t *testing.T) {
 					[]string{"whatever", "delete", "--ignore-not-found=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -252,7 +280,9 @@ func TestManagerDelete(t *testing.T) {
 					[]string{"kubectl", "delete", "--context", "whatever", "--ignore-not-found=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 
@@ -268,7 +298,9 @@ func TestManagerDelete(t *testing.T) {
 					[]string{"kubectl", "delete", "--kubeconfig", "whatever", "--ignore-not-found=true", "--filename", "-"},
 					"test",
 				)
-				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("StdoutPipe", mock.MatchedBy(exp)).Once().Return(nopRC, nil)
+				mc.On("Start", mock.MatchedBy(exp)).Once().Return(nil)
+				mc.On("Wait", mock.MatchedBy(exp)).Once().Return(nil)
 			},
 		},
 	}

--- a/internal/resource/manage/kubectl/kubectlmock/cmd_runner.go
+++ b/internal/resource/manage/kubectl/kubectlmock/cmd_runner.go
@@ -3,6 +3,7 @@
 package kubectlmock
 
 import (
+	io "io"
 	exec "os/exec"
 
 	mock "github.com/stretchr/testify/mock"
@@ -13,13 +14,64 @@ type CmdRunner struct {
 	mock.Mock
 }
 
-// Run provides a mock function with given fields: _a0
-func (_m *CmdRunner) Run(_a0 *exec.Cmd) error {
-	ret := _m.Called(_a0)
+// Run provides a mock function with given fields: c
+func (_m *CmdRunner) Run(c *exec.Cmd) error {
+	ret := _m.Called(c)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*exec.Cmd) error); ok {
-		r0 = rf(_a0)
+		r0 = rf(c)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Start provides a mock function with given fields: c
+func (_m *CmdRunner) Start(c *exec.Cmd) error {
+	ret := _m.Called(c)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*exec.Cmd) error); ok {
+		r0 = rf(c)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// StdoutPipe provides a mock function with given fields: c
+func (_m *CmdRunner) StdoutPipe(c *exec.Cmd) (io.ReadCloser, error) {
+	ret := _m.Called(c)
+
+	var r0 io.ReadCloser
+	if rf, ok := ret.Get(0).(func(*exec.Cmd) io.ReadCloser); ok {
+		r0 = rf(c)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.ReadCloser)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*exec.Cmd) error); ok {
+		r1 = rf(c)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Wait provides a mock function with given fields: c
+func (_m *CmdRunner) Wait(c *exec.Cmd) error {
+	ret := _m.Called(c)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*exec.Cmd) error); ok {
+		r0 = rf(c)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Closes #106

This PR changes how we capture the outputs of the executed commands:

- Diff commands (diff + kubectl diff) will output to stdout (as before).
- Rest of the commands (kubectl apply, delete...) will stream the output using our logger.
- All commands now will store the stderr in a buffer, and in case of error, while executing the command, this buffer will be printed line by line as a `log.Error`, and added all the buffer to the returned error.
