### PR TITLE
Remove name from Resource model because is not used

### DIFF
--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -18,7 +18,6 @@ type K8sObject interface {
 type Resource struct {
 	ID           string
 	GroupID      string
-	Name         string
 	ManifestPath string
 	K8sObject    K8sObject
 }

--- a/internal/resource/manage/kubectl/diff_test.go
+++ b/internal/resource/manage/kubectl/diff_test.go
@@ -73,7 +73,7 @@ func TestDiffManagerApply(t *testing.T) {
 		},
 
 		"Having an error while encoding objects should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, errors.New("whatever"))
 			},
@@ -81,7 +81,7 @@ func TestDiffManagerApply(t *testing.T) {
 		},
 
 		"Having an error while running the cmd should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, nil)
 				mc.On("Run", mock.Anything).Once().Return(errors.New("whatever"))
@@ -91,8 +91,8 @@ func TestDiffManagerApply(t *testing.T) {
 
 		"Having resources should apply correctly.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
-				{Name: "test2", K8sObject: newK8sObject("test2", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns1")},
 			},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				expK8sResources := []model.K8sObject{
@@ -113,7 +113,7 @@ func TestDiffManagerApply(t *testing.T) {
 			config: kubectl.DiffManagerConfig{
 				KubectlCmd: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -129,7 +129,7 @@ func TestDiffManagerApply(t *testing.T) {
 			config: kubectl.DiffManagerConfig{
 				KubeContext: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -145,7 +145,7 @@ func TestDiffManagerApply(t *testing.T) {
 			config: kubectl.DiffManagerConfig{
 				KubeConfig: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -161,7 +161,7 @@ func TestDiffManagerApply(t *testing.T) {
 			config: kubectl.DiffManagerConfig{
 				DisableKubeForceConflicts: true,
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -177,7 +177,7 @@ func TestDiffManagerApply(t *testing.T) {
 			config: kubectl.DiffManagerConfig{
 				KubeFieldManager: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -237,7 +237,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while encoding objects to get the latest state from the resources in the server, should fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -248,7 +248,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while running kubctl get to get the latest state from the resources in the server, should fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -260,7 +260,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while decodding latest received state from the server, should fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -273,7 +273,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while creating the tmp dir should stop execution and fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -289,7 +289,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while encoding resource should stop execution and fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -308,7 +308,7 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having an error while storing encoded resource should stop execution and fail.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				// Getting server state part.
@@ -328,9 +328,9 @@ func TestDiffManagerDelete(t *testing.T) {
 
 		"Having resources should delete correctly.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
-				{Name: "test2", K8sObject: newK8sObject("test2", "ns2")},
-				{Name: "test3", K8sObject: newK8sObject("test3", "ns3")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns2")},
+				{ID: "test3", K8sObject: newK8sObject("test3", "ns3")},
 			},
 			mock: func(mke *kubectlmock.K8sObjectEncoder, mkd *kubectlmock.K8sObjectDecoder, mc *kubectlmock.CmdRunner, mfs *kubectlmock.FSManager) {
 				expK8sResources1 := newK8sObject("test1", "ns1")

--- a/internal/resource/manage/kubectl/kubectl_test.go
+++ b/internal/resource/manage/kubectl/kubectl_test.go
@@ -36,8 +36,8 @@ func TestManagerApply(t *testing.T) {
 
 		"Having resources should apply correctly.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
-				{Name: "test2", K8sObject: newK8sObject("test2", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns1")},
 			},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				expK8sResources := []model.K8sObject{
@@ -58,7 +58,7 @@ func TestManagerApply(t *testing.T) {
 		},
 
 		"Having an error while encoding objects should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, errors.New("whatever"))
 			},
@@ -66,7 +66,7 @@ func TestManagerApply(t *testing.T) {
 		},
 
 		"Having an error while running the cmd should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, nil)
 				mc.On("StdoutPipe", mock.Anything).Once().Return(nopRC, nil)
@@ -80,7 +80,7 @@ func TestManagerApply(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubectlCmd: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -98,7 +98,7 @@ func TestManagerApply(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubeContext: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -116,7 +116,7 @@ func TestManagerApply(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubeConfig: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -134,7 +134,7 @@ func TestManagerApply(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				DisableKubeForceConflicts: true,
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -152,7 +152,7 @@ func TestManagerApply(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubeFieldManager: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -211,8 +211,8 @@ func TestManagerDelete(t *testing.T) {
 
 		"Having resources should delete correctly.": {
 			resources: []model.Resource{
-				{Name: "test1", K8sObject: newK8sObject("test1", "ns1")},
-				{Name: "test2", K8sObject: newK8sObject("test2", "ns1")},
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns1")},
 			},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				expK8sResources := []model.K8sObject{
@@ -232,7 +232,7 @@ func TestManagerDelete(t *testing.T) {
 		},
 
 		"Having an error while encoding objects should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, errors.New("whatever"))
 			},
@@ -240,7 +240,7 @@ func TestManagerDelete(t *testing.T) {
 		},
 
 		"Having an error while running the cmd should stop the execution and fail.": {
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return(nil, nil)
 				mc.On("StdoutPipe", mock.Anything).Once().Return(nopRC, nil)
@@ -254,7 +254,7 @@ func TestManagerDelete(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubectlCmd: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -272,7 +272,7 @@ func TestManagerDelete(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubeContext: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 
@@ -290,7 +290,7 @@ func TestManagerDelete(t *testing.T) {
 			config: kubectl.ManagerConfig{
 				KubeConfig: "whatever",
 			},
-			resources: []model.Resource{{Name: "test1"}},
+			resources: []model.Resource{{ID: "test1"}},
 			mock: func(mk *kubectlmock.K8sObjectEncoder, mc *kubectlmock.CmdRunner) {
 				mk.On("EncodeObjects", mock.Anything, mock.Anything).Once().Return([]byte("test"), nil)
 

--- a/internal/resource/process/kubemeta_test.go
+++ b/internal/resource/process/kubemeta_test.go
@@ -37,8 +37,7 @@ func newCustomResource(kAPIVersion, kType, ns, name string, labels, annotations 
 		objLabels[k] = v
 	}
 	return model.Resource{
-		ID:   name,
-		Name: name,
+		ID: name,
 		K8sObject: &unstructured.Unstructured{
 			Object: tm{
 				"apiVersion": kAPIVersion,

--- a/internal/storage/fs/fs.go
+++ b/internal/storage/fs/fs.go
@@ -232,7 +232,6 @@ func (r *Repository) loadFS(rootPath string) error {
 			// Store the resource.
 			resources[id] = model.Resource{
 				ID:           id,
-				Name:         obj.GetName(),
 				GroupID:      groupID,
 				ManifestPath: path,
 				K8sObject:    obj,

--- a/internal/storage/fs/fs_test.go
+++ b/internal/storage/fs/fs_test.go
@@ -110,7 +110,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
@@ -147,14 +146,12 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
 				},
 				{
 					ID:           "core/v1/ConfigMap/test-ns2/test-name2",
-					Name:         "test-name2",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns2", "test-name2"),
@@ -200,14 +197,12 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
 				},
 				{
 					ID:           "core/v1/ConfigMap/test-ns2/test-name2",
-					Name:         "test-name2",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-2.yaml",
 					K8sObject:    newConfigmap("test-ns2", "test-name2"),
@@ -263,21 +258,18 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
 				},
 				{
 					ID:           "core/v1/ConfigMap/test-ns2/test-name2",
-					Name:         "test-name2",
 					GroupID:      "group2",
 					ManifestPath: "/tmp/test/group2/test-2.yaml",
 					K8sObject:    newConfigmap("test-ns2", "test-name2"),
 				},
 				{
 					ID:           "core/v1/ConfigMap/test-ns3/test-name3",
-					Name:         "test-name3",
 					GroupID:      "group2/subgroup3",
 					ManifestPath: "/tmp/test/group2/subgroup3/test-3.yaml",
 					K8sObject:    newConfigmap("test-ns3", "test-name3"),
@@ -313,7 +305,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "root",
 					ManifestPath: "/tmp/test/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
@@ -348,7 +339,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "whatever",
 					ManifestPath: "/tmp/test/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
@@ -416,7 +406,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name3",
-					Name:         "test-name3",
 					GroupID:      "group3",
 					ManifestPath: "/tmp/test/group3/test3.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name3"),
@@ -463,7 +452,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group2",
 					ManifestPath: "/tmp/test/group2/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),
@@ -557,7 +545,6 @@ func TestRepositoryLoadFS(t *testing.T) {
 			expResources: []model.Resource{
 				{
 					ID:           "core/v1/ConfigMap/test-ns/test-name",
-					Name:         "test-name",
 					GroupID:      "group1",
 					ManifestPath: "/tmp/test/group1/test-1.yaml",
 					K8sObject:    newConfigmap("test-ns", "test-name"),


### PR DESCRIPTION
`Name` field in the Model is not used, this field was here as a friendlier way of visualizing the ID, but our IDs are friendly enough (api_version/kind/ns/name). So we are removing it.