### PR TITLE
Allow the user creating missing namespaces before applying resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 - Optional annotation filter for resources using Kubernetes standard label selectors using `--kube-include-annotation` flag.
 - Load `metav1.List` YAML resources as individual resources.
 - Allow groups waiting specific time after apply.
-- Add `fs-include` and `fs-exclude` arg options to kahoy app global configuration file as an alternative.
+- `fs-include` and `fs-exclude` arg options to kahoy app global configuration file as an alternative.
 - JSON report with the resources applied and deleted after the execution.
-- Confirmation prompt when running `kahoy apply` without diff or dry_run modes enabled. Optional flag `--auto-approve` to disable the prompt, useful for non interactive scenarios like CI.
+- Confirmation prompt when running `kahoy apply` without diff or dry-run modes enabled.
+- Optional `--auto-approve` to disable the confirmation prompt.
+- Optional `--create-namespace` on regular and diff modes that will create missing namespaces of applied resources.
 
 ### Changed
 

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -56,6 +56,7 @@ type CmdConfig struct {
 		IncludeChanges           bool
 		ReportPath               string
 		AutoApprove              bool
+		CreateNamespace          bool
 	}
 }
 
@@ -93,6 +94,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("include-changes", "Excludes all the resources without changes (old vs new states).").Short('f').BoolVar(&c.Apply.IncludeChanges)
 	apply.Flag("report-path", "Path to a file where the report data will be written, use `-` for stdout or nothing to disable").Short('r').StringVar(&c.Apply.ReportPath)
 	apply.Flag("auto-approve", "applies changes without asking for confirmation. Useful to run Kahoy on non interactive scenarios like CI.").BoolVar(&c.Apply.AutoApprove)
+	apply.Flag("create-namespace", "creates missing namespaces of the applied resources, used in regular and diff exacution modes.").BoolVar(&c.Apply.CreateNamespace)
 
 	// Deprecated flags.
 	apply.Flag("git-diff-filter", "DEPRECATED, use --include-changes.").Hidden().BoolVar(&c.Apply.IncludeChanges)

--- a/internal/resource/manage/kubectl/diff.go
+++ b/internal/resource/manage/kubectl/diff.go
@@ -285,6 +285,8 @@ func (d diffManager) Delete(ctx context.Context, resources []model.Resource) err
 // Existing resources will be returned with the fields data up to date (server data).
 // If any of the resources is not on the server it will not be returned.
 func (d diffManager) getResourcesFromAPIServer(ctx context.Context, objs []model.K8sObject) ([]model.K8sObject, error) {
+	logger := d.logger.WithValues(log.Kv{"ext-cmd": "kubectl"})
+
 	// Encode objects.
 	yamlData, err := d.yamlEncoder.EncodeObjects(ctx, objs)
 	if err != nil {
@@ -306,7 +308,7 @@ func (d diffManager) getResourcesFromAPIServer(ctx context.Context, objs []model
 			if line == "" {
 				continue
 			}
-			d.logger.Errorf(line)
+			logger.Errorf(line)
 		}
 		return nil, fmt.Errorf("error while running delete diff command: %s: %w", outErr.String(), err)
 	}

--- a/internal/resource/manage/kubectl/diff_test.go
+++ b/internal/resource/manage/kubectl/diff_test.go
@@ -22,15 +22,18 @@ import (
 // expCmdMatcher returns an *exec.Cmd matcher for  mock.MatchedBy.
 func expCmdMatcher(expArgs []string, expInput string) func(cmd *exec.Cmd) bool {
 	return func(cmd *exec.Cmd) bool {
-		data, err := ioutil.ReadAll(cmd.Stdin)
-		if err != nil {
-			return false
-		}
-		// Write back in case further checks are made.
-		cmd.Stdin = bytes.NewReader(data)
+		if expInput != "" {
+			data, err := ioutil.ReadAll(cmd.Stdin)
+			if err != nil {
+				return false
+			}
 
-		if string(data) != expInput {
-			return false
+			// Write back in case further checks are made.
+			cmd.Stdin = bytes.NewReader(data)
+
+			if string(data) != expInput {
+				return false
+			}
 		}
 
 		if len(expArgs) != len(cmd.Args) {

--- a/internal/resource/manage/kubectl/ns.go
+++ b/internal/resource/manage/kubectl/ns.go
@@ -1,0 +1,180 @@
+package kubectl
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/slok/kahoy/internal/log"
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/resource/manage"
+)
+
+// NamespaceEnsurerConfig is the configuration for NewNamespaceEnsurer.
+type NamespaceEnsurerConfig struct {
+	// Manager is the original manager used to apply and delete.
+	Manager     manage.ResourceManager
+	KubectlCmd  string
+	KubeConfig  string
+	KubeContext string
+	CmdRunner   CmdRunner
+	Out         io.Writer
+	ErrOut      io.Writer
+	Logger      log.Logger
+}
+
+func (c *NamespaceEnsurerConfig) defaults() error {
+	if c.Manager == nil {
+		return fmt.Errorf("resource manager is required")
+	}
+
+	if c.KubectlCmd == "" {
+		c.KubectlCmd = "kubectl"
+	}
+
+	if c.Out == nil {
+		c.Out = os.Stdout
+	}
+
+	if c.ErrOut == nil {
+		c.ErrOut = os.Stderr
+	}
+
+	if c.Logger == nil {
+		c.Logger = log.Noop
+	}
+	c.Logger = c.Logger.WithValues(log.Kv{"app-svc": "kubectl.NamespaceEnsurer"})
+
+	if c.CmdRunner == nil {
+		c.CmdRunner = newStdCmdRunner(c.Logger)
+	}
+
+	return nil
+}
+
+type namespaceEnsurer struct {
+	manager     manage.ResourceManager
+	kubectlCmd  string
+	kubeConfig  string
+	kubeContext string
+	cmdRunner   CmdRunner
+	out         io.Writer
+	errOut      io.Writer
+	logger      log.Logger
+}
+
+// NewNamespaceEnsurer returns a resource Manager based on Kubctl that will ensure
+// the namespace of the applied resources are present before applying them.
+func NewNamespaceEnsurer(config NamespaceEnsurerConfig) (manage.ResourceManager, error) {
+	err := config.defaults()
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return namespaceEnsurer{
+		manager:     config.Manager,
+		kubectlCmd:  config.KubectlCmd,
+		kubeConfig:  config.KubeConfig,
+		kubeContext: config.KubeContext,
+		cmdRunner:   config.CmdRunner,
+		out:         config.Out,
+		errOut:      config.ErrOut,
+		logger:      config.Logger,
+	}, nil
+}
+
+func (n namespaceEnsurer) Apply(ctx context.Context, resources []model.Resource) error {
+	namespaces := map[string]struct{}{}
+	for _, r := range resources {
+		ns := r.K8sObject.GetNamespace()
+		if ns == "" {
+			continue
+		}
+
+		namespaces[ns] = struct{}{}
+	}
+
+	// Ensure the Namespaces are present.
+	for ns := range namespaces {
+		err := n.ensureNamespace(ctx, ns)
+		if err != nil {
+			return fmt.Errorf("could not ensure namespace %q: %w", ns, err)
+		}
+	}
+
+	return n.manager.Apply(ctx, resources)
+}
+
+func (n namespaceEnsurer) Delete(ctx context.Context, resources []model.Resource) error {
+	return n.manager.Delete(ctx, resources)
+}
+
+func (n namespaceEnsurer) ensureNamespace(ctx context.Context, ns string) error {
+	logger := n.logger.WithValues(log.Kv{"ext-cmd": "kubectl"})
+
+	// Check if the ns is missing.
+	{
+		getArgs := newKubectlCmdArgs([]kubectlCmdOption{
+			withGetCmd(),
+			withContext(n.kubeContext),
+			withConfig(n.kubeConfig),
+			withNamespaceKind(),
+			withResourceName(ns),
+		})
+
+		cmd := exec.CommandContext(ctx, n.kubectlCmd, getArgs...)
+		var outErr bytes.Buffer
+		cmd.Stderr = &outErr
+		err := n.cmdRunner.Run(cmd)
+		if err == nil {
+			// Namespace already present.
+			return nil
+		}
+
+		// Check if the error is of missing ns.
+		// Errors of missing ns are in this way: `Error from server (NotFound): namespaces "xxxxxx" not found`.
+		errorData := outErr.String()
+		if !strings.Contains(strings.ToLower(errorData), "notfound") {
+			return fmt.Errorf("could not get ns info: %s: %w", errorData, err)
+		}
+	}
+
+	// Create the ns.
+	{
+		createArgs := newKubectlCmdArgs([]kubectlCmdOption{
+			withCreateCmd(),
+			withContext(n.kubeContext),
+			withConfig(n.kubeConfig),
+			withNamespaceKind(),
+			withResourceName(ns),
+		})
+
+		var out, outErr bytes.Buffer
+		cmd := exec.CommandContext(ctx, n.kubectlCmd, createArgs...)
+		cmd.Stdout = &out
+		cmd.Stderr = &outErr
+		err := n.cmdRunner.Run(cmd)
+		if err != nil {
+			for _, line := range strings.Split(outErr.String(), "\n") {
+				if line == "" {
+					continue
+				}
+				logger.Errorf(line)
+			}
+			return fmt.Errorf("error while executing create namespace command: %s: %w", outErr.String(), err)
+		}
+
+		for _, line := range strings.Split(out.String(), "\n") {
+			if line == "" {
+				continue
+			}
+			logger.Infof(line)
+		}
+	}
+
+	return nil
+}

--- a/internal/resource/manage/kubectl/ns_test.go
+++ b/internal/resource/manage/kubectl/ns_test.go
@@ -1,0 +1,226 @@
+package kubectl_test
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/resource/manage/kubectl"
+	"github.com/slok/kahoy/internal/resource/manage/kubectl/kubectlmock"
+	"github.com/slok/kahoy/internal/resource/manage/managemock"
+)
+
+// expCmdMatcher returns an *exec.Cmd matcher for  mock.MatchedBy.
+func expCmdMatcherWithRetStderr(expArgs []string, returnStderrData string) func(cmd *exec.Cmd) bool {
+	return func(cmd *exec.Cmd) bool {
+		_, _ = cmd.Stderr.Write([]byte(returnStderrData))
+
+		if len(expArgs) != len(cmd.Args) {
+			return false
+		}
+
+		for i, arg := range expArgs {
+			if arg != cmd.Args[i] {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+func TestNamespaceEnsurerApply(t *testing.T) {
+	tests := map[string]struct {
+		config    kubectl.NamespaceEnsurerConfig
+		resources []model.Resource
+		mock      func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner)
+		expErr    bool
+	}{
+		"Not having resources, should delegate to the delegated manager.": {
+			resources: []model.Resource{},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				mrm.On("Apply", mock.Anything, []model.Resource{}).Once().Return(nil)
+			},
+		},
+
+		"Having an error on delegated manager, should fail.": {
+			resources: []model.Resource{},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				mrm.On("Apply", mock.Anything, mock.Anything).Once().Return(errors.New("whatever"))
+			},
+			expErr: true,
+		},
+
+		"Having resources with missing namespaces, should create the namespace once per unique namespace and delegate apply afterwards.": {
+			resources: []model.Resource{
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns2")},
+				{ID: "test3", K8sObject: newK8sObject("test3", "ns1")},
+			},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				// Expect namespaces checks and creation.
+				exp := expCmdMatcherWithRetStderr([]string{"kubectl", "get", "namespace", "ns1"}, `Error from server (NotFound): namespaces "ns1" not found`)
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(errors.New("no namespace"))
+				exp = expCmdMatcher([]string{"kubectl", "create", "namespace", "ns1"}, "")
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+
+				exp = expCmdMatcherWithRetStderr([]string{"kubectl", "get", "namespace", "ns2"}, `Error from server (NotFound): namespaces "ns1" not found`)
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(errors.New("no namespace"))
+				exp = expCmdMatcher([]string{"kubectl", "create", "namespace", "ns2"}, "")
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+
+				// Expect delegation.
+				expRes := []model.Resource{
+					{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+					{ID: "test2", K8sObject: newK8sObject("test2", "ns2")},
+					{ID: "test3", K8sObject: newK8sObject("test3", "ns1")},
+				}
+				mrm.On("Apply", mock.Anything, expRes).Once().Return(nil)
+			},
+		},
+
+		"Having an error while checking namespace existence should fail.": {
+			resources: []model.Resource{
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+			},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				// Expect namespaces checks.
+				exp := expCmdMatcherWithRetStderr([]string{"kubectl", "get", "namespace", "ns1"}, `other error getting the namespace`)
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(errors.New("no namespace"))
+
+				mrm.On("Apply", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+			expErr: true,
+		},
+
+		"Having resources with present namespaces, should not create the namespaces.": {
+			resources: []model.Resource{
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+			},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				// Expect namespaces checks.
+				exp := expCmdMatcher([]string{"kubectl", "get", "namespace", "ns1"}, "")
+				mc.On("Run", mock.MatchedBy(exp)).Once().Return(nil)
+
+				mrm.On("Apply", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+		},
+
+		"Empty namespaces should be ignored.": {
+			resources: []model.Resource{
+				{ID: "test1", K8sObject: newK8sObject("test1", "")},
+			},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				mrm.On("Apply", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Mocks.
+			mrm := &managemock.ResourceManager{}
+			mcmd := &kubectlmock.CmdRunner{}
+			test.mock(mrm, mcmd)
+
+			// Prepare.
+			test.config.Out = ioutil.Discard
+			test.config.CmdRunner = mcmd
+			test.config.Manager = mrm
+			manager, err := kubectl.NewNamespaceEnsurer(test.config)
+			require.NoError(err)
+
+			// Execute.
+			err = manager.Apply(context.TODO(), test.resources)
+
+			// Check.
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				mrm.AssertExpectations(t)
+				mcmd.AssertExpectations(t)
+			}
+		})
+	}
+}
+
+func TestNamespaceEnsurerDelete(t *testing.T) {
+	tests := map[string]struct {
+		config    kubectl.NamespaceEnsurerConfig
+		resources []model.Resource
+		mock      func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner)
+		expErr    bool
+	}{
+		"Not having resources, should delegate to the delegated manager.": {
+			resources: []model.Resource{},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				mrm.On("Delete", mock.Anything, []model.Resource{}).Once().Return(nil)
+			},
+		},
+
+		"Having an error on delegated manager, should fail.": {
+			resources: []model.Resource{},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				mrm.On("Delete", mock.Anything, mock.Anything).Once().Return(errors.New("whatever"))
+			},
+			expErr: true,
+		},
+
+		"Having resources should delegate to the delegated manager.": {
+			resources: []model.Resource{
+				{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+				{ID: "test2", K8sObject: newK8sObject("test2", "ns2")},
+				{ID: "test3", K8sObject: newK8sObject("test3", "ns1")},
+			},
+			mock: func(mrm *managemock.ResourceManager, mc *kubectlmock.CmdRunner) {
+				// Expect delegation.
+				expRes := []model.Resource{
+					{ID: "test1", K8sObject: newK8sObject("test1", "ns1")},
+					{ID: "test2", K8sObject: newK8sObject("test2", "ns2")},
+					{ID: "test3", K8sObject: newK8sObject("test3", "ns1")},
+				}
+				mrm.On("Delete", mock.Anything, expRes).Once().Return(nil)
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Mocks.
+			mrm := &managemock.ResourceManager{}
+			mcmd := &kubectlmock.CmdRunner{}
+			test.mock(mrm, mcmd)
+
+			// Prepare.
+			test.config.Out = ioutil.Discard
+			test.config.CmdRunner = mcmd
+			test.config.Manager = mrm
+			manager, err := kubectl.NewNamespaceEnsurer(test.config)
+			require.NoError(err)
+
+			// Execute.
+			err = manager.Delete(context.TODO(), test.resources)
+
+			// Check.
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				mrm.AssertExpectations(t)
+				mcmd.AssertExpectations(t)
+			}
+		})
+	}
+}

--- a/internal/resource/manage/kubectl/options.go
+++ b/internal/resource/manage/kubectl/options.go
@@ -39,6 +39,24 @@ func withDiffCmd() kubectlCmdOption {
 	}
 }
 
+func withCreateCmd() kubectlCmdOption {
+	return func(args []string) []string {
+		return append(args, "create")
+	}
+}
+
+func withNamespaceKind() kubectlCmdOption {
+	return func(args []string) []string {
+		return append(args, "namespace")
+	}
+}
+
+func withResourceName(name string) kubectlCmdOption {
+	return func(args []string) []string {
+		return append(args, name)
+	}
+}
+
 func withContext(context string) kubectlCmdOption {
 	return func(args []string) []string {
 		if context == "" {


### PR DESCRIPTION
Closes #113 

This PR adds `--create-namespace` flag. This flag will ensure that the applied resources have the ns before being applied, this is checking if are present, in case they are not, it will create them.

This will work with regular apply and diff.

It has been implemented using a wrapper `manage.ResourceManager`, that will create the missing namespaces before calling the delegated `manage.ResourceManager`.