### PR TITLE
Rename parameter --mode into --provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@
 - File based filtering (include exclude).
 - Kubernetes type filtering (exclude).
 - Add States repositories (old and new).
-- Paths mode (load from fs).
-- Git mode (load form Git repository).
+- Paths provider (load from fs).
+- Git provider (load form Git repository).
 - Git filtering based on `git diff`.
 - Git states based on previous commit or `git merge-base`.
 - Grouping of resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 - `--kube-exclude-type` short flag changed from `-a` to `-t`, `--kube-include-annotation` is `-a` short flag.
+- `--mode` flag renamed to `--provider`.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ kubectl config set-context kind-kahoy
 
 Kahoy comes with a handy set of use cases for manual testing. You can check them in [`tests/manual`][manual-tests]. These tests come with a `run.sh` file that will run the different use cases with some predefined flags for Kahoy.
 
-How these use cases work is simple, they use `--mode=paths`, and we have different manifest directories in different states.
+How these use cases work is simple, they use `--provider=paths`, and we have different manifest directories in different states.
 
 - [`manifests-all`][manifests-all]: It has all the resources.
 - [`manifests-shuffle`][manifests-shuffle]: It has all resources but with different structure.

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -33,9 +33,9 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 	}
 
 	logger := globalConfig.Logger.WithValues(log.Kv{
-		"id":   report.ID,
-		"cmd":  "apply",
-		"mode": cmdConfig.Apply.Mode,
+		"id":       report.ID,
+		"cmd":      "apply",
+		"provider": cmdConfig.Apply.Provider,
 	})
 	logger.Infof("running command")
 
@@ -50,8 +50,8 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 		oldResourceRepo, newResourceRepo storage.ResourceRepository
 		newGroupRepo                     storage.GroupRepository
 	)
-	switch cmdConfig.Apply.Mode {
-	case ApplyModeGit:
+	switch cmdConfig.Apply.Provider {
+	case ApplyProviderGit:
 		oldRepo, newRepo, err := storagegit.NewRepositories(storagegit.RepositoriesConfig{
 			ExcludeRegex:       fsExclude,
 			IncludeRegex:       fsInclude,
@@ -71,7 +71,7 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 		newResourceRepo = newRepo
 		newGroupRepo = newRepo
 
-	case ApplyModePaths:
+	case ApplyProviderPaths:
 		oldRepo, newRepo, err := storagefs.NewRepositories(storagefs.RepositoriesConfig{
 			ExcludeRegex:      fsExclude,
 			IncludeRegex:      fsInclude,
@@ -89,7 +89,7 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 		newResourceRepo = newRepo
 		newGroupRepo = newRepo
 	default:
-		return fmt.Errorf("unknown apply mode: %s", cmdConfig.Apply.Mode)
+		return fmt.Errorf("unknown apply provider: %s", cmdConfig.Apply.Provider)
 	}
 
 	// Get resources from repositories.

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -18,10 +18,10 @@ const (
 	DefaultConfigFile = "kahoy.yml"
 )
 
-// Apply modes.
+// Apply providers.
 const (
-	ApplyModePaths = "paths"
-	ApplyModeGit   = "git"
+	ApplyProviderPaths = "paths"
+	ApplyProviderGit   = "git"
 )
 
 // CmdConfig is the configuration of the command
@@ -51,7 +51,7 @@ type CmdConfig struct {
 		KubeAnnotationSelector   string
 		GitBeforeCommit          string
 		GitDefaultBranch         string
-		Mode                     string
+		Provider                 string
 		DryRun                   bool
 		IncludeChanges           bool
 		ReportPath               string
@@ -81,7 +81,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("kube-context", "Kubernetes configuration context.").StringVar(&c.Apply.KubeContext)
 	apply.Flag("diff", "Diff instead of applying changes.").BoolVar(&c.Apply.DiffMode)
 	apply.Flag("dry-run", "Execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
-	apply.Flag("mode", "Selects how apply will select the state, load manifests... git needs to be executed from a git repository.").Default(ApplyModeGit).EnumVar(&c.Apply.Mode, ApplyModePaths, ApplyModeGit)
+	apply.Flag("provider", "Selects which provider to use to load the old and new states. Git needs to be executed from a git repository.").Default(ApplyProviderGit).EnumVar(&c.Apply.Provider, ApplyProviderPaths, ApplyProviderGit)
 	apply.Flag("fs-old-manifests-path", "Kubernetes current manifests path.").Short('o').StringVar(&c.Apply.ManifestsPathOld)
 	apply.Flag("fs-new-manifests-path", "Kubernetes expected manifests path.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
 	apply.Flag("fs-exclude", "Regex to ignore manifest files and dirs. Can be repeated.").Short('e').StringsVar(&c.Apply.ExcludeManifests)
@@ -116,13 +116,13 @@ func (c *CmdConfig) validate() error {
 		return fmt.Errorf(`only one of "dry run" and "diff" execution modes can be used at the same time`)
 	}
 
-	switch c.Apply.Mode {
-	case ApplyModePaths:
+	switch c.Apply.Provider {
+	case ApplyProviderPaths:
 		if c.Apply.ManifestsPathOld == "" {
-			return fmt.Errorf("manifests old path is required when using %q mode", ApplyModePaths)
+			return fmt.Errorf("manifests old path is required when using %q provider", ApplyProviderPaths)
 		}
 
-	case ApplyModeGit:
+	case ApplyProviderGit:
 		if c.Apply.ManifestsPathOld == "" {
 			c.Apply.ManifestsPathOld = c.Apply.ManifestsPathNew
 		}
@@ -131,7 +131,7 @@ func (c *CmdConfig) validate() error {
 			return fmt.Errorf(`at least one of "git default branch" or "git before commit" is required`)
 		}
 	default:
-		return fmt.Errorf("unknown mode: %q", c.Apply.Mode)
+		return fmt.Errorf("unknown provider: %q", c.Apply.Provider)
 	}
 
 	return nil

--- a/tests/manual/run.sh
+++ b/tests/manual/run.sh
@@ -16,7 +16,7 @@ function kahoy_apply() {
     new_path="${1}"
 
     go run ./cmd/kahoy apply \
-        --mode "paths" \
+        --provider "paths" \
         --config-file "${config_file}" \
         --fs-old-manifests-path "${all_path}" \
         --fs-new-manifests-path "${new_path}"


### PR DESCRIPTION
Related to https://github.com/slok/kahoy/issues/117

Note: **This is a breaking change**

We felt that the attribute `--mode` was misleading in regards to selecting how kahoy should fetch the states to compare and apply resources. Instead we find `provider` a more appropiate word.