### PR TITLE
Add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Documentation base.
+- Documentation page.
+- `version` command.
 
 ## [v2.0.0] - 2020-10-05
 

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -10,7 +10,8 @@ import (
 
 // Commandline subcommands IDs.
 const (
-	CmdArgApply = "apply"
+	CmdArgApply   = "apply"
+	CmdArgVersion = "version"
 )
 
 // Defaults.
@@ -103,6 +104,9 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("kube-provider-namespace", "Kubernetes storage provider namespace.").Default("default").StringVar(&c.Apply.KubeProviderNs)
 	apply.Flag("include-namespace", "Regex to include certain namespaces and ignore everything else. It's useful to scope down the execution. Can be repeated.").StringsVar(&c.Apply.IncludeNamespaces)
 
+	// Version command.
+	app.Command(CmdArgVersion, "Show application version.")
+
 	// Parse the commandline.
 	cmd, err := app.Parse(args)
 	if err != nil {
@@ -119,6 +123,17 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 }
 
 func (c *CmdConfig) validate() error {
+	switch c.Command {
+	case CmdArgApply:
+		return c.validateApply()
+	case CmdArgVersion:
+		return nil
+	}
+
+	return nil
+}
+
+func (c *CmdConfig) validateApply() error {
 	if c.Apply.DryRun && c.Apply.DiffMode {
 		return fmt.Errorf(`only one of "dry run" and "diff" execution modes can be used at the same time`)
 	}

--- a/cmd/kahoy/main.go
+++ b/cmd/kahoy/main.go
@@ -100,7 +100,8 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 	{
 		// Mapping for each command func and select the correct one.
 		commands := map[string]func(ctx context.Context, config CmdConfig, globalConfig GlobalConfig) error{
-			CmdArgApply: RunApply,
+			CmdArgApply:   RunApply,
+			CmdArgVersion: RunVersion,
 		}
 		cmd, ok := commands[config.Command]
 		if !ok {

--- a/cmd/kahoy/version.go
+++ b/cmd/kahoy/version.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunVersion runs version command.
+func RunVersion(_ context.Context, _ CmdConfig, globalConfig GlobalConfig) error {
+	fmt.Fprintln(globalConfig.Stdout, Version)
+
+	return nil
+}


### PR DESCRIPTION
This adds a new command called `version`, at this moment we _only_ had a global flag called `--version`, some people are used to the command and lots of common tools like `kubectl`, have a command instead of a flag.

