### PR TITLE
Fix kahoy plan typo

### DIFF
--- a/docs-src/content/topics/concepts.md
+++ b/docs-src/content/topics/concepts.md
@@ -101,6 +101,4 @@ Check [providers section]({{< relref "provider/" >}}) for more information.
 
 ## Kahoy Plan
 
-Kahoy plan is a command that creates an execution plan for the user to inspect.
-It's calculated based on the old and new states and prompts the user with all
-the meaningful information about the incoming changes.
+Kahoy plan creates an execution plan for the user to inspect. It's calculated based on the old and new states and prompts the user with all the meaningful information about the upcoming changes.

--- a/docs-src/content/topics/how-does-it-work.md
+++ b/docs-src/content/topics/how-does-it-work.md
@@ -24,4 +24,4 @@ A pipeline is probably the best way to illustrate all the things that are happen
   - Store state.
   - Output the resulting changes.
 
-The above pipeline is also a good example to show what Kahoy doesn't do. Please visit the [scope of this project]({{< relref "/introduction/alternatives-and-scope.md#scope">}}) if you are missing any other functionality.
+The above pipeline is also a good example to show what Kahoy doesn't do. Please visit the [scope of this project]({{< relref "/introduction/scope-and-alternatives.md#scope">}}) if you are missing any other functionality.


### PR DESCRIPTION
This PR: 
- Corrects a typo in concepts.md
- Fixes up a reference to scope and alternatives 