### PR TITLE
Timeouts for Kahoy execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Documentation page.
 - `version` command.
 - Override Kubectl path with `--kubectl-path` flag.
+- Default 5 minute timeout for any apply operation.
+- `--execution-timeout` flag for the apply method to override the default timeout
 
 ## [v2.0.0] - 2020-10-05
 

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -22,6 +22,7 @@ import (
 	managedryrun "github.com/slok/kahoy/internal/resource/manage/dryrun"
 	"github.com/slok/kahoy/internal/resource/manage/kubectl"
 	managekubectl "github.com/slok/kahoy/internal/resource/manage/kubectl"
+	"github.com/slok/kahoy/internal/resource/manage/timeout"
 	managewait "github.com/slok/kahoy/internal/resource/manage/wait"
 	resourceprocess "github.com/slok/kahoy/internal/resource/process"
 	"github.com/slok/kahoy/internal/storage"
@@ -257,6 +258,16 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 
 			reportRepo = storagereport.NewJSONStateRepository(outFile)
 		}
+	}
+
+	// Wrap resource manager with timeout manager
+	manager, err = timeout.NewTimeoutManager(timeout.TimeoutManagerConfig{
+		Timeout: 5 * time.Minute,
+		Manager: manager,
+		Logger:  logger,
+	})
+	if err != nil {
+		return fmt.Errorf("could not create timeout manager: %w", err)
 	}
 
 	// Wrap manager with batch manager. This should wrap the executors managers

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -22,7 +22,7 @@ import (
 	managedryrun "github.com/slok/kahoy/internal/resource/manage/dryrun"
 	"github.com/slok/kahoy/internal/resource/manage/kubectl"
 	managekubectl "github.com/slok/kahoy/internal/resource/manage/kubectl"
-	"github.com/slok/kahoy/internal/resource/manage/timeout"
+	manageTimeout "github.com/slok/kahoy/internal/resource/manage/timeout"
 	managewait "github.com/slok/kahoy/internal/resource/manage/wait"
 	resourceprocess "github.com/slok/kahoy/internal/resource/process"
 	"github.com/slok/kahoy/internal/storage"
@@ -262,7 +262,7 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 
 	// Wrap resource manager with timeout manager if timeout is properly set
 	if cmdConfig.Apply.ExecutionTimeout != 0 {
-		manager, err = timeout.NewTimeoutManager(timeout.TimeoutManagerConfig{
+		manager, err = manageTimeout.NewTimeoutManager(manageTimeout.TimeoutManagerConfig{
 			Timeout: cmdConfig.Apply.ExecutionTimeout,
 			Manager: manager,
 			Logger:  logger,

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -262,7 +262,7 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 
 	// Wrap resource manager with timeout manager
 	manager, err = timeout.NewTimeoutManager(timeout.TimeoutManagerConfig{
-		Timeout: 5 * time.Minute,
+		Timeout: cmdConfig.Apply.ExecutionTimeout,
 		Manager: manager,
 		Logger:  logger,
 	})

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -260,14 +260,16 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 		}
 	}
 
-	// Wrap resource manager with timeout manager
-	manager, err = timeout.NewTimeoutManager(timeout.TimeoutManagerConfig{
-		Timeout: cmdConfig.Apply.ExecutionTimeout,
-		Manager: manager,
-		Logger:  logger,
-	})
-	if err != nil {
-		return fmt.Errorf("could not create timeout manager: %w", err)
+	// Wrap resource manager with timeout manager if timeout is properly set
+	if cmdConfig.Apply.ExecutionTimeout != 0 {
+		manager, err = timeout.NewTimeoutManager(timeout.TimeoutManagerConfig{
+			Timeout: cmdConfig.Apply.ExecutionTimeout,
+			Manager: manager,
+			Logger:  logger,
+		})
+		if err != nil {
+			return fmt.Errorf("could not create timeout manager: %w", err)
+		}
 	}
 
 	// Wrap manager with batch manager. This should wrap the executors managers

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -107,7 +107,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("kube-provider-id", "Kubernetes storage provider ID.").StringVar(&c.Apply.KubeProviderID)
 	apply.Flag("kube-provider-namespace", "Kubernetes storage provider namespace.").Default("default").StringVar(&c.Apply.KubeProviderNs)
 	apply.Flag("include-namespace", "Regex to include certain namespaces and ignore everything else. It's useful to scope down the execution. Can be repeated.").StringsVar(&c.Apply.IncludeNamespaces)
-	apply.Flag("execution-timeout", "This argments sets a timeout for each apply execution. It's optional and the default timeout is set to 5 minutes.").Default("5m").DurationVar(&c.Apply.ExecutionTimeout)
+	apply.Flag("execution-timeout", "This argments sets a timeout for each apply and delete execution. Use 0 to disable.").Default("5m").DurationVar(&c.Apply.ExecutionTimeout)
 
 	// Version command.
 	app.Command(CmdArgVersion, "Show application version.")

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/client-go/util/homedir"
@@ -63,6 +64,7 @@ type CmdConfig struct {
 		KubeProviderID           string
 		KubeProviderNs           string
 		IncludeNamespaces        []string
+		ExecutionTimeout         time.Duration
 	}
 }
 
@@ -105,6 +107,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("kube-provider-id", "Kubernetes storage provider ID.").StringVar(&c.Apply.KubeProviderID)
 	apply.Flag("kube-provider-namespace", "Kubernetes storage provider namespace.").Default("default").StringVar(&c.Apply.KubeProviderNs)
 	apply.Flag("include-namespace", "Regex to include certain namespaces and ignore everything else. It's useful to scope down the execution. Can be repeated.").StringsVar(&c.Apply.IncludeNamespaces)
+	apply.Flag("execution-timeout", "This argments sets a timeout for each apply execution. It's optional and the default timeout is set to 5 minutes.").Default("5m").DurationVar(&c.Apply.ExecutionTimeout)
 
 	// Version command.
 	app.Command(CmdArgVersion, "Show application version.")

--- a/internal/resource/manage/timeout/timeout.go
+++ b/internal/resource/manage/timeout/timeout.go
@@ -36,7 +36,7 @@ func (c *TimeoutManagerConfig) defaults() error {
 }
 
 // NewTimeoutManager wraps the application resource manager ensuring that the
-// executions to either apply or delete resources have timeouts.
+// executions to either apply or delete resources has timeouts.
 func NewTimeoutManager(config TimeoutManagerConfig) (manage.ResourceManager, error) {
 	err := config.defaults()
 	if err != nil {

--- a/internal/resource/manage/timeout/timeout.go
+++ b/internal/resource/manage/timeout/timeout.go
@@ -1,0 +1,95 @@
+package timeout
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/slok/kahoy/internal/log"
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/resource/manage"
+)
+
+// TimeoutManagerConfig is the configuration of the timeout resource manager.
+type TimeoutManagerConfig struct {
+	Timeout time.Duration
+	// Manager is the original manager use resourced to apply and delete.
+	Manager manage.ResourceManager
+	Logger  log.Logger
+}
+
+func (c *TimeoutManagerConfig) defaults() error {
+	if c.Manager == nil {
+		return fmt.Errorf("manager is required")
+	}
+
+	if c.Logger == nil {
+		c.Logger = log.Noop
+	}
+	c.Logger = c.Logger.WithValues(log.Kv{"app-svc": "manage.TimeoutManager"})
+
+	if c.Timeout == 0 {
+		c.Timeout = 5 * time.Minute
+	}
+
+	return nil
+}
+
+// NewTimeoutManager wraps the application resource manager ensuring that the
+// executions to either apply or delete resources have timeouts.
+func NewTimeoutManager(config TimeoutManagerConfig) (manage.ResourceManager, error) {
+	err := config.defaults()
+	if err != nil {
+		return nil, fmt.Errorf("invalid timeout manager configuration: %w", err)
+	}
+
+	return timeoutManager{
+		manager: config.Manager,
+		logger:  config.Logger,
+		timeout: config.Timeout,
+	}, nil
+}
+
+type timeoutManager struct {
+	manager manage.ResourceManager
+	logger  log.Logger
+	timeout time.Duration
+}
+
+// Apply wraps timeoutManger internal resourceManager Apply() method around an
+// initialized context with a configured timeout.
+func (t timeoutManager) Apply(ctx context.Context, resources []model.Resource) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	err := t.manager.Apply(ctx, resources)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			t.logger.Errorf("context cancelled by deadline after %s", time.Since(start).Round(time.Millisecond))
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// Apply wraps timeoutManger internal resourceManager Delete() method around an
+// initialized context with a configured timeout.
+func (t timeoutManager) Delete(ctx context.Context, resources []model.Resource) error {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, t.timeout)
+	defer cancel()
+
+	err := t.manager.Delete(ctx, resources)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			t.logger.Errorf("context cancelled by deadline after %s", time.Since(start).Round(time.Millisecond))
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/internal/resource/manage/timeout/timeout_test.go
+++ b/internal/resource/manage/timeout/timeout_test.go
@@ -1,0 +1,73 @@
+package timeout_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/resource/manage/managemock"
+	"github.com/slok/kahoy/internal/resource/manage/timeout"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutManagerApply(t *testing.T) {
+	tests := map[string]struct {
+		config    timeout.TimeoutManagerConfig
+		resources []model.Resource
+		mock      func(mrm *managemock.ResourceManager)
+		expErr    bool
+	}{
+		"Basic initialization should not fail.": {
+			mock: func(mrm *managemock.ResourceManager) {
+				mrm.On("Apply", mock.Anything, mock.Anything).Once().Return(nil)
+			},
+		},
+
+		"If Apply takes longer than timeout, apply should fail.": {
+			config: timeout.TimeoutManagerConfig{
+				Timeout: 1 * time.Second,
+			},
+			resources: []model.Resource{
+				{ID: "resource1", GroupID: "group1"},
+			},
+			mock: func(mrm *managemock.ResourceManager) {
+				expBatch := []model.Resource{
+					{ID: "resource1", GroupID: "group1"},
+				}
+				mrm.On("Apply", mock.Anything, expBatch).Once().Return(nil)
+				// TODO(jesus.vazquez) wait few seconds so manager timeouts
+			},
+			expErr: false, // TODO (jesus.vazquez) switch this to true
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Mocks.
+			mrm := &managemock.ResourceManager{}
+			test.mock(mrm)
+
+			// Execute.
+			test.config.Manager = mrm
+			manager, err := timeout.NewTimeoutManager(test.config)
+			require.NoError(err)
+
+			err = manager.Apply(context.TODO(), test.resources)
+
+			// Check.
+			if test.expErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+			mrm.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/resource/manage/timeout/timeout_test.go
+++ b/internal/resource/manage/timeout/timeout_test.go
@@ -54,6 +54,47 @@ func TestTimeoutManagerApply(t *testing.T) {
 	}
 }
 
+func TestTimeoutManagerDelete(t *testing.T) {
+	tests := map[string]struct {
+		config  timeout.TimeoutManagerConfig
+		manager manage.ResourceManager
+		expErr  bool
+	}{
+		"Basic initialization should not fail.": {
+			manager: testManager{},
+		},
+
+		"If Delete takes longer than timeout, apply should fail.": {
+			config: timeout.TimeoutManagerConfig{
+				Timeout: 1 * time.Nanosecond,
+			},
+			manager: testManager{},
+			expErr:  true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Execute.
+			test.config.Manager = test.manager
+			manager, err := timeout.NewTimeoutManager(test.config)
+			require.NoError(err)
+
+			err = manager.Delete(context.Background(), []model.Resource{})
+
+			// Check.
+			if test.expErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
 // testManager is a custom resource manager that handles context deadline
 // exceeded and returns nil error
 type testManager struct{}


### PR DESCRIPTION
Related to https://github.com/slok/kahoy/issues/158

This PR: 
- [x] Creates timeout manager so that we can handle the execution of apply and delete resources with timeouts.
- [x] Tests
- [x] Initialize it in apply.go before wrapping the manager around the batch priority manager.