### PR TITLE
Add logger formats option with default, simple and json loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Override Kubectl path with `--kubectl-path` flag.
 - Default 5 minute timeout for any apply operation.
 - `--execution-timeout` flag for the apply method to override the default timeout
+- `--logger` flag to set the logger type, available optios are: default, json and simple.
 
 ## [v2.0.0] - 2020-10-05
 

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -15,6 +15,13 @@ const (
 	CmdArgVersion = "version"
 )
 
+// Logger formats.
+const (
+	GlobalLoggerDefault = "default"
+	GlobalLoggerJSON    = "json"
+	GlobalLoggerSimple  = "simple"
+)
+
 // Defaults.
 const (
 	DefaultConfigFile = "kahoy.yml"
@@ -37,6 +44,7 @@ type CmdConfig struct {
 		Debug      bool
 		NoColor    bool
 		NoLog      bool
+		LoggerType string
 		ConfigFile string
 	}
 
@@ -81,6 +89,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	app.Flag("debug", "Enable debug mode.").BoolVar(&c.Global.Debug)
 	app.Flag("no-color", "Disable color.").BoolVar(&c.Global.NoColor)
 	app.Flag("no-log", "Disable logger.").BoolVar(&c.Global.NoLog)
+	app.Flag("logger", "Selects the logger type.").Default(GlobalLoggerDefault).EnumVar(&c.Global.LoggerType, GlobalLoggerDefault, GlobalLoggerJSON, GlobalLoggerSimple)
 	app.Flag("config-file", "App configuration file.").Default(DefaultConfigFile).StringVar(&c.Global.ConfigFile)
 
 	// Apply command.

--- a/cmd/kahoy/main.go
+++ b/cmd/kahoy/main.go
@@ -46,10 +46,20 @@ func Run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		logrusLog := logrus.New()
 		logrusLog.Out = stderr // By default logger goes to stderr (so it can split stdout prints).
 		logrusLogEntry := logrus.NewEntry(logrusLog)
-		logrusLogEntry.Logger.SetFormatter(&logrus.TextFormatter{
-			ForceColors:   !config.Global.NoColor,
-			DisableColors: config.Global.NoColor,
-		})
+
+		// Set logger formatter.
+		switch config.Global.LoggerType {
+		case GlobalLoggerDefault:
+			logrusLogEntry.Logger.SetFormatter(&logrus.TextFormatter{
+				ForceColors:   !config.Global.NoColor,
+				DisableColors: config.Global.NoColor,
+			})
+		case GlobalLoggerJSON:
+			logrusLogEntry.Logger.SetFormatter(&logrus.JSONFormatter{})
+		case GlobalLoggerSimple:
+			logrusLogEntry.Logger.SetFormatter(log.SimpleFormatter)
+		}
+
 		if config.Global.Debug {
 			logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
 		}

--- a/internal/log/simple.go
+++ b/internal/log/simple.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SimpleFormatter is a logrus compatible formatter that only prints the
+// the message of the logger.
+const SimpleFormatter = simpleFormatter(0)
+
+type simpleFormatter int
+
+var _ logrus.Formatter = SimpleFormatter
+
+func (s simpleFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	b := &bytes.Buffer{}
+
+	// Set prefix in case of error or warning.
+	switch entry.Level {
+	case logrus.ErrorLevel, logrus.FatalLevel:
+		fmt.Fprintf(b, "ERROR: ")
+	case logrus.WarnLevel:
+		fmt.Fprintf(b, "WARN: ")
+	}
+
+	// Set message.
+	fmt.Fprintf(b, entry.Message)
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}


### PR DESCRIPTION
This PR focuses on the logger type.

- Add a `--logger` flag to select the logger type.
- Defaults to current logger (`default`).
- Adds `json` logger.
- Add `simple` logger that only prints the messages.