### PR TITLE
Show kubernetes source path as the manifest path for Kubernetes storage retrieved data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Notes
+
+After the cluster scoped resource IDs change (ignores namespaces), Kubernetes storage could duplicate some of the resources state in case your cluster scoped resources had a namespace set by error. Check the warnings of Kubernetes storage `cluster scoped resource has namespace set` message. After fixing your resources, identify Kahoy Kubernetes state and remove them manually using `kubectl delete secret ...`).
+
 ### Added
 
 - Documentation page.
@@ -17,6 +21,7 @@
 ### Changed
 
 - Cluster scoped IDs ignore the namespace field for the kahoy resource ID.
+- Kubernetes storage resources, manifest path data shows to the Kubernetes resource instead of the original fs manifest path.
 
 ## [v2.0.0] - 2020-10-05
 

--- a/internal/storage/kubernetes/kubernetes.go
+++ b/internal/storage/kubernetes/kubernetes.go
@@ -174,6 +174,8 @@ func (r Repository) StoreState(ctx context.Context, state model.State) error {
 	return nil
 }
 
+const kubePathFmt = "kubernetes://%s/%s"
+
 func (r Repository) secretToResource(ctx context.Context, secret *corev1.Secret) (*model.Resource, error) {
 	_, ok := secret.Data[secretResIDKey]
 	if !ok {
@@ -190,7 +192,7 @@ func (r Repository) secretToResource(ctx context.Context, secret *corev1.Secret)
 		return nil, fmt.Errorf("missing resource data in kubernetes secret")
 	}
 
-	path, ok := secret.Data[secretResPathKey]
+	_, ok = secret.Data[secretResPathKey]
 	if !ok {
 		return nil, fmt.Errorf("missing resource fs path in kubernetes secret")
 	}
@@ -200,7 +202,9 @@ func (r Repository) secretToResource(ctx context.Context, secret *corev1.Secret)
 		return nil, fmt.Errorf("could not deserialize kubernetes object data: %w", err)
 	}
 
-	return r.modelFactory.NewResource(kobj, string(group), string(path))
+	path := fmt.Sprintf(kubePathFmt, secret.Namespace, secret.Name)
+
+	return r.modelFactory.NewResource(kobj, string(group), path)
 }
 
 const (

--- a/internal/storage/kubernetes/kubernetes_test.go
+++ b/internal/storage/kubernetes/kubernetes_test.go
@@ -99,7 +99,7 @@ func TestRepositoryGetResource(t *testing.T) {
 				res1 := newResource("pid1", "gid1", "mp1", "ns1", "name1")
 				ms.On("DecodeObjects", mock.Anything, []byte("obj1")).Once().Return([]model.K8sObject{res1.K8sObject}, nil)
 			},
-			exp: newResource("core/v1/ConfigMap/ns1/name1", "gid1", "mp1", "ns1", "name1"),
+			exp: newResource("core/v1/ConfigMap/ns1/name1", "gid1", "kubernetes://test-ns/59d09a913a1718071b37a97cb2caf42d", "ns1", "name1"),
 		},
 
 		"Getting a resource from Kubernetes without raw data should fail.": {
@@ -340,8 +340,8 @@ func TestRepositoryListResources(t *testing.T) {
 			},
 			exp: &storage.ResourceList{
 				Items: []model.Resource{
-					newResource("core/v1/ConfigMap/ns1/name1", "gid1", "mp1", "ns1", "name1"),
-					newResource("core/v1/ConfigMap/ns2/name2", "gid2", "mp2", "ns2", "name2"),
+					newResource("core/v1/ConfigMap/ns1/name1", "gid1", "kubernetes://test-ns/59d09a913a1718071b37a97cb2caf42d", "ns1", "name1"),
+					newResource("core/v1/ConfigMap/ns2/name2", "gid2", "kubernetes://test-ns/2de89034e9e1afcf8cb49226e4433dba", "ns2", "name2"),
 				},
 			},
 		},


### PR DESCRIPTION
Before:

```bash
▶ Apply (1 resources)
└── ▶ alertgram (1 resources)
    └── monitoring.coreos.com/v1/ServiceMonitor/monitoring/alertgram2 (manifests/alertgram/alertgram.yaml)


▶ Delete (2 resources)
└── ▶ alertgram (2 resources)
    ├── core/v1/Service/monitoring/alertgram (manifests/alertgram/alertgram.yaml)
    └── monitoring.coreos.com/v1/ServiceMonitor/monitoring/alertgram (manifests/alertgram/alertgram.yaml)

```

After:
```bash
▶ Apply (1 resources)
└── ▶ alertgram (1 resources)
    └── monitoring.coreos.com/v1/ServiceMonitor/monitoring/alertgram2 (manifests/alertgram/alertgram.yaml)


▶ Delete (2 resources)
└── ▶ alertgram (2 resources)
    ├── core/v1/Service/monitoring/alertgram (kubernetes://ci/cd30ec2a697a47740732396330edd587)
    └── monitoring.coreos.com/v1/ServiceMonitor/monitoring/alertgram (kubernetes://ci/09eaf97c90b08b6b0f669c252a398c56)

```