### PR TITLE
Add stdin provider as an alternative to fs provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ After the cluster scoped resource IDs change (ignores namespaces), Kubernetes st
 - `--delete-first` flag that inverts the actions order on resources, `delete` before `apply`.
 - Kubernetes storage ID validates with the same requirements as a Kubernetes label value.
 - Kahoy checks with the apiserver (using discovery API) if the loaded resource type is known by the API and fail if not.
+- Use `-` in `--fs-new-manifests-path` to load data from `stdin`.
 
 ### Changed
 

--- a/cmd/kahoy/apply.go
+++ b/cmd/kahoy/apply.go
@@ -97,6 +97,8 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 
 	case ApplyProviderPaths:
 		oldRepo, newRepo, err := storagefs.NewRepositories(storagefs.RepositoriesConfig{
+			Ctx:               ctx,
+			StdIn:             globalConfig.Stdin,
 			ExcludeRegex:      fsExclude,
 			IncludeRegex:      fsInclude,
 			OldPath:           cmdConfig.Apply.ManifestsPathOld,
@@ -128,6 +130,8 @@ func RunApply(ctx context.Context, cmdConfig CmdConfig, globalConfig GlobalConfi
 		}
 
 		_, newRepo, err := storagefs.NewRepositories(storagefs.RepositoriesConfig{
+			Ctx:               ctx,
+			StdIn:             globalConfig.Stdin,
 			ExcludeRegex:      fsExclude,
 			IncludeRegex:      fsInclude,
 			OldPath:           os.DevNull,

--- a/cmd/kahoy/config.go
+++ b/cmd/kahoy/config.go
@@ -102,7 +102,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	apply.Flag("dry-run", "Execute in dry-run, is safe, can be run without Kubernetes cluster.").BoolVar(&c.Apply.DryRun)
 	apply.Flag("provider", "Selects which provider to use to load the old and new states. Git needs to be executed from a git repository.").Default(ApplyProviderK8s).EnumVar(&c.Apply.Provider, ApplyProviderPaths, ApplyProviderGit, ApplyProviderK8s)
 	apply.Flag("fs-old-manifests-path", "Kubernetes current manifests path.").Short('o').StringVar(&c.Apply.ManifestsPathOld)
-	apply.Flag("fs-new-manifests-path", "Kubernetes expected manifests path.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
+	apply.Flag("fs-new-manifests-path", "Kubernetes expected manifests path, use `-` for stdin.").Short('n').Required().StringVar(&c.Apply.ManifestsPathNew)
 	apply.Flag("fs-exclude", "Regex to ignore manifest files and dirs. Can be repeated.").Short('e').StringsVar(&c.Apply.ExcludeManifests)
 	apply.Flag("fs-include", "Regex to include manifest files and dirs, everything else will be ignored. Exclude has preference. Can be repeated.").Short('i').StringsVar(&c.Apply.IncludeManifests)
 	apply.Flag("git-before-commit-sha", "The git hash used as the old state to get the apply/delete plan, if not passed, it will search using merge-base common ancestor of current HEAD and default branch.").Short('c').StringVar(&c.Apply.GitBeforeCommit)

--- a/internal/storage/fs/factory.go
+++ b/internal/storage/fs/factory.go
@@ -1,14 +1,25 @@
 package fs
 
 import (
+	"context"
 	"fmt"
+	"io"
 
 	"github.com/slok/kahoy/internal/log"
 	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/storage"
 )
+
+// ResourceGroupRepository implements ResourceRepository and GroupRepository.
+type ResourceGroupRepository interface {
+	storage.ResourceRepository
+	storage.GroupRepository
+}
 
 // RepositoriesConfig is the configuration for NewRepositories
 type RepositoriesConfig struct {
+	Ctx               context.Context
+	StdIn             io.Reader
 	ExcludeRegex      []string
 	IncludeRegex      []string
 	OldPath           string
@@ -19,9 +30,9 @@ type RepositoriesConfig struct {
 	Logger            log.Logger
 }
 
-// NewRepositories is a factory that knows how to return two fs repositories based on common options
-// at the end you will have an old FS repository and a new FS repository.
-func NewRepositories(config RepositoriesConfig) (oldRepo, newRepo *Repository, err error) {
+// NewRepositories is a factory that knows how to return two fs/stdin repositories based on common options
+// at the end you will have an old FS repository and a new fs/stdin repository.
+func NewRepositories(config RepositoriesConfig) (oldRepo, newRepo ResourceGroupRepository, err error) {
 	oldRepo, err = NewRepository(RepositoryConfig{
 		ExcludeRegex:      config.ExcludeRegex,
 		IncludeRegex:      config.IncludeRegex,
@@ -37,19 +48,36 @@ func NewRepositories(config RepositoriesConfig) (oldRepo, newRepo *Repository, e
 		return nil, nil, fmt.Errorf("could not create old fs %q repository storage: %w", config.OldPath, err)
 	}
 
-	newRepo, err = NewRepository(RepositoryConfig{
-		ExcludeRegex:      config.ExcludeRegex,
-		IncludeRegex:      config.IncludeRegex,
-		Path:              config.NewPath,
-		KubernetesDecoder: config.KubernetesDecoder,
-		AppConfig:         config.AppConfig,
-		ModelFactory:      config.ModelFactory,
-		Logger: config.Logger.WithValues(log.Kv{
-			"repo-state": "new",
-		}),
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("could not create new fs %q repository storage: %w", config.NewPath, err)
+	// Select FS based repo or stdin.
+	if config.NewPath == "-" {
+		newRepo, err = NewIOReaderRepository(IOReaderRepositoryConfig{
+			Ctx:               config.Ctx,
+			Reader:            config.StdIn,
+			KubernetesDecoder: config.KubernetesDecoder,
+			AppConfig:         config.AppConfig,
+			ModelFactory:      config.ModelFactory,
+			Logger: config.Logger.WithValues(log.Kv{
+				"repo-state": "new",
+			}),
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not create new stdin repository storage: %w", err)
+		}
+	} else {
+		newRepo, err = NewRepository(RepositoryConfig{
+			ExcludeRegex:      config.ExcludeRegex,
+			IncludeRegex:      config.IncludeRegex,
+			Path:              config.NewPath,
+			KubernetesDecoder: config.KubernetesDecoder,
+			AppConfig:         config.AppConfig,
+			ModelFactory:      config.ModelFactory,
+			Logger: config.Logger.WithValues(log.Kv{
+				"repo-state": "new",
+			}),
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not create new fs %q repository storage: %w", config.NewPath, err)
+		}
 	}
 
 	return oldRepo, newRepo, nil

--- a/internal/storage/fs/fs.go
+++ b/internal/storage/fs/fs.go
@@ -249,7 +249,6 @@ func (r *Repository) loadFS(rootPath string) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("could not load fs manifests: %w", err)
 	}

--- a/internal/storage/fs/stdin.go
+++ b/internal/storage/fs/stdin.go
@@ -1,0 +1,204 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/slok/kahoy/internal/internalerrors"
+	"github.com/slok/kahoy/internal/log"
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/storage"
+	storagememory "github.com/slok/kahoy/internal/storage/memory"
+)
+
+// IOReaderRepository returns resources from io.Reader.
+type IOReaderRepository struct {
+	k8sDecoder   K8sObjectDecoder
+	logger       log.Logger
+	rootGroupID  string
+	appConfig    model.AppConfig
+	modelFactory *model.ResourceAndGroupFactory
+
+	resourceMemoryRepo storagememory.ResourceRepository
+	groupMemoryRepo    storagememory.GroupRepository
+}
+
+// Interface assertion.
+var (
+	_ storage.ResourceRepository = &Repository{}
+	_ storage.GroupRepository    = &Repository{}
+)
+
+// IOReaderRepositoryConfig is the configuration of IOReaderRepository.
+type IOReaderRepositoryConfig struct {
+	Ctx               context.Context
+	LoadTimeout       time.Duration
+	Reader            io.Reader
+	KubernetesDecoder K8sObjectDecoder
+	RootGroupID       string
+	Logger            log.Logger
+	AppConfig         *model.AppConfig
+	ModelFactory      *model.ResourceAndGroupFactory
+}
+
+func (c *IOReaderRepositoryConfig) defaults() error {
+	if c.Ctx == nil {
+		c.Ctx = context.Background()
+	}
+
+	if c.LoadTimeout == 0 {
+		// Enough time to get data from stdin. We just want to avoid getting stuck forever
+		// waiting for something that will not come.
+		c.LoadTimeout = 10 * time.Second
+	}
+
+	if c.Reader == nil {
+		return fmt.Errorf("reader is required")
+	}
+
+	if c.KubernetesDecoder == nil {
+		return fmt.Errorf("kubernetes object loader is required")
+	}
+
+	if c.Logger == nil {
+		c.Logger = log.Noop
+	}
+	c.Logger = c.Logger.WithValues(log.Kv{
+		"app-svc": "fs.IOReaderRepository",
+	})
+
+	if c.ModelFactory == nil {
+		return fmt.Errorf("resource and group model factory is required")
+	}
+
+	if c.RootGroupID == "" {
+		c.RootGroupID = "root"
+	}
+
+	if c.AppConfig == nil {
+		return fmt.Errorf("app configuration is required")
+	}
+
+	return nil
+}
+
+// NewIOReaderRepository returns a new NewIOReaderRepository.
+// it will load all the resource and groups from the received io.Reader.
+// the loaded resources will be loaded into a memory repository.
+func NewIOReaderRepository(config IOReaderRepositoryConfig) (*IOReaderRepository, error) {
+	err := config.defaults()
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	r := &IOReaderRepository{
+		k8sDecoder:   config.KubernetesDecoder,
+		logger:       config.Logger,
+		rootGroupID:  config.RootGroupID,
+		appConfig:    *config.AppConfig,
+		modelFactory: config.ModelFactory,
+	}
+
+	ctx, cancel := context.WithTimeout(config.Ctx, config.LoadTimeout)
+	defer cancel()
+	err = r.load(ctx, config.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("could not load repository from reader: %w", err)
+	}
+
+	return r, nil
+}
+
+func (i *IOReaderRepository) load(ctx context.Context, r io.Reader) error {
+	data, err := i.readData(ctx, r)
+	if err != nil {
+		return fmt.Errorf("could not read data: %w", err)
+	}
+
+	objs, err := i.k8sDecoder.DecodeObjects(context.Background(), data)
+	if err != nil {
+		return fmt.Errorf("could not load kubernetes objects: %w", err)
+	}
+
+	resources := map[string]model.Resource{}
+	for _, obj := range objs {
+
+		resource, err := i.modelFactory.NewResource(obj, i.rootGroupID, "stdin")
+		if err != nil {
+			return fmt.Errorf("could not create model resource: %w", err)
+		}
+
+		// Check if we already have this resource.
+		_, ok := resources[resource.ID]
+		if ok {
+			return fmt.Errorf("%w: resource collision with %s", internalerrors.ErrNotValid, resource.ID)
+		}
+
+		// Store the resource.
+		resources[resource.ID] = *resource
+	}
+
+	// Stdin only has the root group.
+	rootGroupConfig := i.appConfig.Groups[i.rootGroupID]
+	groups := map[string]model.Group{
+		i.rootGroupID: i.modelFactory.NewGroup(i.rootGroupID, "", rootGroupConfig),
+	}
+
+	i.resourceMemoryRepo = storagememory.NewResourceRepository(resources)
+	i.groupMemoryRepo = storagememory.NewGroupRepository(groups)
+
+	return nil
+}
+
+func (i *IOReaderRepository) readData(ctx context.Context, r io.Reader) ([]byte, error) {
+	var data []byte
+	var err error
+
+	c := make(chan error)
+	go func() {
+		data, err = ioutil.ReadAll(r)
+		if err != nil {
+			c <- fmt.Errorf("could not read data from io.Reader: %w", err)
+		}
+		c <- nil
+	}()
+
+	// Wait for read.
+	select {
+	case <-ctx.Done():
+		err := fmt.Errorf("repository could not read data from io.Reader, context done")
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = fmt.Errorf("%s: %w", err, ctxErr)
+		}
+		return nil, err
+	case err = <-c:
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return data, nil
+}
+
+// GetResource satisfies storage.ResourceRepository interface.
+func (i *IOReaderRepository) GetResource(ctx context.Context, id string) (*model.Resource, error) {
+	return i.resourceMemoryRepo.GetResource(ctx, id)
+}
+
+// ListResources satisfies storage.ResourceRepository interface.
+func (i *IOReaderRepository) ListResources(ctx context.Context, opts storage.ResourceListOpts) (*storage.ResourceList, error) {
+	return i.resourceMemoryRepo.ListResources(ctx, opts)
+}
+
+// GetGroup satisfies storage.GroupRepository interface.
+func (i *IOReaderRepository) GetGroup(ctx context.Context, id string) (*model.Group, error) {
+	return i.groupMemoryRepo.GetGroup(ctx, id)
+}
+
+// ListGroups satisfies storage.GroupRepository interface.
+func (i *IOReaderRepository) ListGroups(ctx context.Context, opts storage.GroupListOpts) (*storage.GroupList, error) {
+	return i.groupMemoryRepo.ListGroups(ctx, opts)
+}

--- a/internal/storage/fs/stdin_test.go
+++ b/internal/storage/fs/stdin_test.go
@@ -1,0 +1,154 @@
+package fs_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/slok/kahoy/internal/model"
+	"github.com/slok/kahoy/internal/storage"
+	"github.com/slok/kahoy/internal/storage/fs"
+	"github.com/slok/kahoy/internal/storage/fs/fsmock"
+)
+
+func TestIOReaderRepositoryLoad(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := map[string]struct {
+		cfg          fs.IOReaderRepositoryConfig
+		mock         func(mkd *fsmock.K8sObjectDecoder)
+		expResources []model.Resource
+		expGroups    []model.Group
+		expErr       bool
+	}{
+		"If no reader given, it should fail.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				AppConfig: &model.AppConfig{},
+			},
+			mock:         func(mkd *fsmock.K8sObjectDecoder) {},
+			expResources: []model.Resource{},
+			expGroups:    []model.Group{},
+			expErr:       true,
+		},
+
+		"Data with resources should return the resource and groups.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				AppConfig: &model.AppConfig{},
+				Reader:    strings.NewReader(`somedata`),
+			},
+			mock: func(mkd *fsmock.K8sObjectDecoder) {
+				objs := []model.K8sObject{
+					newConfigmap("test-ns", "test-name"),
+					newConfigmap("test-ns2", "test-name2"),
+				}
+				mkd.On("DecodeObjects", mock.Anything, []byte("somedata")).Once().Return(objs, nil)
+			},
+			expResources: []model.Resource{
+				{
+					ID:           "core/v1/ConfigMap/test-ns/test-name",
+					GroupID:      "root",
+					ManifestPath: "stdin",
+					K8sObject:    newConfigmap("test-ns", "test-name"),
+				},
+				{
+					ID:           "core/v1/ConfigMap/test-ns2/test-name2",
+					GroupID:      "root",
+					ManifestPath: "stdin",
+					K8sObject:    newConfigmap("test-ns2", "test-name2"),
+				},
+			},
+			expGroups: []model.Group{
+				{ID: "root", Path: "", Priority: 1000},
+			},
+			expErr: false,
+		},
+
+		"Repeated resources on data, should fail.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				AppConfig: &model.AppConfig{},
+				Reader:    strings.NewReader(`somedata`),
+			},
+			mock: func(mkd *fsmock.K8sObjectDecoder) {
+				objs := []model.K8sObject{
+					newConfigmap("test-ns", "test-name"),
+					newConfigmap("test-ns", "test-name"),
+				}
+				mkd.On("DecodeObjects", mock.Anything, mock.Anything).Once().Return(objs, nil)
+			},
+			expErr: true,
+		},
+
+		"Having errors when loading resources should fail.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				AppConfig: &model.AppConfig{},
+				Reader:    strings.NewReader(`somedata`),
+			},
+			mock: func(mkd *fsmock.K8sObjectDecoder) {
+				mkd.On("DecodeObjects", mock.Anything, mock.Anything).Once().Return(nil, fmt.Errorf("whatever"))
+			},
+			expErr: true,
+		},
+
+		"Context done should end loading process.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				Ctx:       cancelledCtx,
+				AppConfig: &model.AppConfig{},
+				Reader:    strings.NewReader(`somedata`),
+			},
+			mock:   func(mkd *fsmock.K8sObjectDecoder) {},
+			expErr: true,
+		},
+
+		"A timeout while loading should error.": {
+			cfg: fs.IOReaderRepositoryConfig{
+				LoadTimeout: 1,
+				AppConfig:   &model.AppConfig{},
+				Reader:      strings.NewReader(`somedata`),
+			},
+			mock:   func(mkd *fsmock.K8sObjectDecoder) {},
+			expErr: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Mocks.
+			mkd := &fsmock.K8sObjectDecoder{}
+			test.mock(mkd)
+
+			// Load and check errors.
+			test.cfg.KubernetesDecoder = mkd
+			test.cfg.ModelFactory = newModelResourceAndGroupFactory()
+			repo, err := fs.NewIOReaderRepository(test.cfg)
+
+			if test.expErr {
+				assert.Error(err)
+			} else if assert.NoError(err) {
+				// Check loaded resources.
+				gotResources, err := repo.ListResources(context.TODO(), storage.ResourceListOpts{})
+				require.NoError(err)
+				sort.SliceStable(test.expResources, func(i, j int) bool { return test.expResources[i].ID < test.expResources[j].ID })
+				sort.SliceStable(gotResources.Items, func(i, j int) bool { return gotResources.Items[i].ID < gotResources.Items[j].ID })
+				assert.Equal(test.expResources, gotResources.Items)
+
+				// Check loaded groups.
+				gotGroups, err := repo.ListGroups(context.TODO(), storage.GroupListOpts{})
+				require.NoError(err)
+				sort.SliceStable(test.expGroups, func(i, j int) bool { return test.expGroups[i].ID < test.expGroups[j].ID })
+				sort.SliceStable(gotGroups.Items, func(i, j int) bool { return gotGroups.Items[i].ID < gotGroups.Items[j].ID })
+				assert.Equal(test.expGroups, gotGroups.Items)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Contributes #187 

Example:

```
cat ./tests/manual/manifests-all/root1.yaml | kahoy apply --dry-run --no-log --kube-provider-id test -n-

▶️ Apply (1 resources)
└── ▶️ root (1 resources)
    └── apps/v1/Deployment/test-kahoy/app-root1 (stdin)
```